### PR TITLE
feat(api): add organization roles and member assignment

### DIFF
--- a/drizzle/0024_overrated_steve_rogers.sql
+++ b/drizzle/0024_overrated_steve_rogers.sql
@@ -1,0 +1,130 @@
+ALTER TABLE "anmategra_organization_unit" DROP CONSTRAINT "anmategra_organization_unit_parent_id_anmategra_organization_unit_id_fk";
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "anmategra_association_request" ADD CONSTRAINT "anmategra_association_request_org_unit_id_anmategra_organization_unit_id_fk" FOREIGN KEY ("org_unit_id") REFERENCES "public"."anmategra_organization_unit"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "anmategra_association_request" ADD CONSTRAINT "anmategra_association_request_org_role_id_anmategra_organization_role_id_fk" FOREIGN KEY ("org_role_id") REFERENCES "public"."anmategra_organization_role"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "anmategra_association_request_lembaga" ADD CONSTRAINT "anmategra_association_request_lembaga_org_unit_id_anmategra_organization_unit_id_fk" FOREIGN KEY ("org_unit_id") REFERENCES "public"."anmategra_organization_unit"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "anmategra_association_request_lembaga" ADD CONSTRAINT "anmategra_association_request_lembaga_org_role_id_anmategra_organization_role_id_fk" FOREIGN KEY ("org_role_id") REFERENCES "public"."anmategra_organization_role"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "anmategra_keanggotaan" ADD CONSTRAINT "anmategra_keanggotaan_org_unit_id_anmategra_organization_unit_id_fk" FOREIGN KEY ("org_unit_id") REFERENCES "public"."anmategra_organization_unit"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "anmategra_keanggotaan" ADD CONSTRAINT "anmategra_keanggotaan_org_role_id_anmategra_organization_role_id_fk" FOREIGN KEY ("org_role_id") REFERENCES "public"."anmategra_organization_role"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "anmategra_kehimpunan" ADD CONSTRAINT "anmategra_kehimpunan_org_unit_id_anmategra_organization_unit_id_fk" FOREIGN KEY ("org_unit_id") REFERENCES "public"."anmategra_organization_unit"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "anmategra_kehimpunan" ADD CONSTRAINT "anmategra_kehimpunan_org_role_id_anmategra_organization_role_id_fk" FOREIGN KEY ("org_role_id") REFERENCES "public"."anmategra_organization_role"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "anmategra_organization_unit" ADD CONSTRAINT "anmategra_organization_unit_parent_id_anmategra_organization_unit_id_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."anmategra_organization_unit"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "keanggotaan_org_unit_idx" ON "anmategra_keanggotaan" USING btree ("org_unit_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "keanggotaan_org_role_idx" ON "anmategra_keanggotaan" USING btree ("org_role_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "kehimpunan_org_unit_idx" ON "anmategra_kehimpunan" USING btree ("org_unit_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "kehimpunan_org_role_idx" ON "anmategra_kehimpunan" USING btree ("org_role_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "organization_role_structure_idx" ON "anmategra_organization_role" USING btree ("structure_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "organization_structure_active_lembaga_unique" ON "anmategra_organization_structure" USING btree ("lembaga_id") WHERE "anmategra_organization_structure"."is_active" = true AND "anmategra_organization_structure"."lembaga_id" IS NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "organization_structure_active_event_unique" ON "anmategra_organization_structure" USING btree ("event_id") WHERE "anmategra_organization_structure"."is_active" = true AND "anmategra_organization_structure"."event_id" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "organization_unit_structure_idx" ON "anmategra_organization_unit" USING btree ("structure_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "organization_unit_parent_idx" ON "anmategra_organization_unit" USING btree ("parent_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "organization_unit_sibling_order_idx" ON "anmategra_organization_unit" USING btree ("structure_id","parent_id","sort_order");--> statement-breakpoint
+-- ---------------------------------------------------------------------------
+-- Hand-written below this line.
+--
+-- drizzle-kit 0.24.2 does not serialize CHECK constraints at all (drizzle-orm
+-- exports check(), but the kit silently emits nothing for it), so these cannot
+-- be expressed in schema.ts. Do NOT run `npm run db:push` on this database:
+-- push diffs the live DB against schema.ts, where these do not exist, and can
+-- propose dropping them. Use `npm run db:migrate` only.
+--
+-- Checked against the phase3-5 dump (53 structures / 105 units / 152 roles)
+-- before writing: every constraint below is satisfied by that data.
+-- ---------------------------------------------------------------------------
+DO $$ BEGIN
+ ALTER TABLE "anmategra_organization_structure"
+   ADD CONSTRAINT "organization_structure_owner_xor"
+   CHECK (num_nonnulls("lembaga_id", "event_id") = 1);
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "anmategra_organization_unit"
+   ADD CONSTRAINT "organization_unit_kind_check"
+   CHECK ("kind" IN ('Bidang', 'Divisi', 'Subdivisi'));
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+-- `level` is DEPTH in the tree, not a function of `kind`: existing data is flat,
+-- with Divisi sitting at level 1 as a root. Ordering rules between kinds are
+-- enforced in the router instead.
+DO $$ BEGIN
+ ALTER TABLE "anmategra_organization_unit"
+   ADD CONSTRAINT "organization_unit_level_range_check"
+   CHECK ("level" BETWEEN 1 AND 3);
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "anmategra_organization_unit"
+   ADD CONSTRAINT "organization_unit_root_parent_check"
+   CHECK (
+     ("level" = 1 AND "parent_id" IS NULL) OR
+     ("level" > 1 AND "parent_id" IS NOT NULL)
+   );
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+-- Composite FK: a unit's parent must live in the same structure. This is the
+-- only guarantee here that survives a script or psql session bypassing the API.
+DO $$ BEGIN
+ ALTER TABLE "anmategra_organization_unit"
+   ADD CONSTRAINT "organization_unit_id_structure_unique"
+   UNIQUE ("id", "structure_id");
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "anmategra_organization_unit"
+   ADD CONSTRAINT "organization_unit_parent_same_structure_fk"
+   FOREIGN KEY ("parent_id", "structure_id")
+   REFERENCES "anmategra_organization_unit"("id", "structure_id")
+   ON DELETE NO ACTION ON UPDATE NO ACTION;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/drizzle/meta/0024_snapshot.json
+++ b/drizzle/meta/0024_snapshot.json
@@ -1,0 +1,2506 @@
+{
+  "id": "a9ee4398-64bf-4725-8faa-72a31086aec9",
+  "prevId": "2ee10c41-ce21-4143-ae2d-a5e63c858eaf",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.anmategra_account": {
+      "name": "anmategra_account",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anmategra_account_user_id_anmategra_user_id_fk": {
+          "name": "anmategra_account_user_id_anmategra_user_id_fk",
+          "tableFrom": "anmategra_account",
+          "tableTo": "anmategra_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "anmategra_account_provider_provider_account_id_pk": {
+          "name": "anmategra_account_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_association_request": {
+      "name": "anmategra_association_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_unit_id": {
+          "name": "org_unit_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_role_id": {
+          "name": "org_role_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "association_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_association_request_event_id_anmategra_event_id_fk": {
+          "name": "anmategra_association_request_event_id_anmategra_event_id_fk",
+          "tableFrom": "anmategra_association_request",
+          "tableTo": "anmategra_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "anmategra_association_request_user_id_anmategra_user_id_fk": {
+          "name": "anmategra_association_request_user_id_anmategra_user_id_fk",
+          "tableFrom": "anmategra_association_request",
+          "tableTo": "anmategra_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "anmategra_association_request_org_unit_id_anmategra_organization_unit_id_fk": {
+          "name": "anmategra_association_request_org_unit_id_anmategra_organization_unit_id_fk",
+          "tableFrom": "anmategra_association_request",
+          "tableTo": "anmategra_organization_unit",
+          "columnsFrom": [
+            "org_unit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "anmategra_association_request_org_role_id_anmategra_organization_role_id_fk": {
+          "name": "anmategra_association_request_org_role_id_anmategra_organization_role_id_fk",
+          "tableFrom": "anmategra_association_request",
+          "tableTo": "anmategra_organization_role",
+          "columnsFrom": [
+            "org_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_association_request_lembaga": {
+      "name": "anmategra_association_request_lembaga",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lembaga_id": {
+          "name": "lembaga_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_unit_id": {
+          "name": "org_unit_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_role_id": {
+          "name": "org_role_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "association_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_association_request_lembaga_lembaga_id_anmategra_lembaga_id_fk": {
+          "name": "anmategra_association_request_lembaga_lembaga_id_anmategra_lembaga_id_fk",
+          "tableFrom": "anmategra_association_request_lembaga",
+          "tableTo": "anmategra_lembaga",
+          "columnsFrom": [
+            "lembaga_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "anmategra_association_request_lembaga_user_id_anmategra_user_id_fk": {
+          "name": "anmategra_association_request_lembaga_user_id_anmategra_user_id_fk",
+          "tableFrom": "anmategra_association_request_lembaga",
+          "tableTo": "anmategra_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "anmategra_association_request_lembaga_org_unit_id_anmategra_organization_unit_id_fk": {
+          "name": "anmategra_association_request_lembaga_org_unit_id_anmategra_organization_unit_id_fk",
+          "tableFrom": "anmategra_association_request_lembaga",
+          "tableTo": "anmategra_organization_unit",
+          "columnsFrom": [
+            "org_unit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "anmategra_association_request_lembaga_org_role_id_anmategra_organization_role_id_fk": {
+          "name": "anmategra_association_request_lembaga_org_role_id_anmategra_organization_role_id_fk",
+          "tableFrom": "anmategra_association_request_lembaga",
+          "tableTo": "anmategra_organization_role",
+          "columnsFrom": [
+            "org_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_best_staff_kegiatan": {
+      "name": "anmategra_best_staff_kegiatan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mahasiswa_id": {
+          "name": "mahasiswa_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_best_staff_kegiatan_event_id_anmategra_event_id_fk": {
+          "name": "anmategra_best_staff_kegiatan_event_id_anmategra_event_id_fk",
+          "tableFrom": "anmategra_best_staff_kegiatan",
+          "tableTo": "anmategra_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "anmategra_best_staff_kegiatan_mahasiswa_id_anmategra_mahasiswa_user_id_fk": {
+          "name": "anmategra_best_staff_kegiatan_mahasiswa_id_anmategra_mahasiswa_user_id_fk",
+          "tableFrom": "anmategra_best_staff_kegiatan",
+          "tableTo": "anmategra_mahasiswa",
+          "columnsFrom": [
+            "mahasiswa_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_best_staff_lembaga": {
+      "name": "anmategra_best_staff_lembaga",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lembaga_id": {
+          "name": "lembaga_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mahasiswa_id": {
+          "name": "mahasiswa_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_best_staff_lembaga_lembaga_id_anmategra_lembaga_id_fk": {
+          "name": "anmategra_best_staff_lembaga_lembaga_id_anmategra_lembaga_id_fk",
+          "tableFrom": "anmategra_best_staff_lembaga",
+          "tableTo": "anmategra_lembaga",
+          "columnsFrom": [
+            "lembaga_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "anmategra_best_staff_lembaga_mahasiswa_id_anmategra_mahasiswa_user_id_fk": {
+          "name": "anmategra_best_staff_lembaga_mahasiswa_id_anmategra_mahasiswa_user_id_fk",
+          "tableFrom": "anmategra_best_staff_lembaga",
+          "tableTo": "anmategra_mahasiswa",
+          "columnsFrom": [
+            "mahasiswa_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_event": {
+      "name": "anmategra_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_image": {
+          "name": "background_image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oprec_link": {
+          "name": "oprec_link",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_limit": {
+          "name": "participant_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "participant_count": {
+          "name": "participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_highlighted": {
+          "name": "is_highlighted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_organogram": {
+          "name": "is_organogram",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "organogram_image": {
+          "name": "organogram_image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rapor_visible": {
+          "name": "rapor_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "event_org_highlighted_unique": {
+          "name": "event_org_highlighted_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anmategra_event\".\"is_highlighted\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anmategra_event_org_id_anmategra_lembaga_id_fk": {
+          "name": "anmategra_event_org_id_anmategra_lembaga_id_fk",
+          "tableFrom": "anmategra_event",
+          "tableTo": "anmategra_lembaga",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_keanggotaan": {
+      "name": "anmategra_keanggotaan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_unit_id": {
+          "name": "org_unit_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_role_id": {
+          "name": "org_role_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "keanggotaan_event_user_unique": {
+          "name": "keanggotaan_event_user_unique",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "keanggotaan_org_unit_idx": {
+          "name": "keanggotaan_org_unit_idx",
+          "columns": [
+            {
+              "expression": "org_unit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "keanggotaan_org_role_idx": {
+          "name": "keanggotaan_org_role_idx",
+          "columns": [
+            {
+              "expression": "org_role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anmategra_keanggotaan_event_id_anmategra_event_id_fk": {
+          "name": "anmategra_keanggotaan_event_id_anmategra_event_id_fk",
+          "tableFrom": "anmategra_keanggotaan",
+          "tableTo": "anmategra_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "anmategra_keanggotaan_user_id_anmategra_user_id_fk": {
+          "name": "anmategra_keanggotaan_user_id_anmategra_user_id_fk",
+          "tableFrom": "anmategra_keanggotaan",
+          "tableTo": "anmategra_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "anmategra_keanggotaan_org_unit_id_anmategra_organization_unit_id_fk": {
+          "name": "anmategra_keanggotaan_org_unit_id_anmategra_organization_unit_id_fk",
+          "tableFrom": "anmategra_keanggotaan",
+          "tableTo": "anmategra_organization_unit",
+          "columnsFrom": [
+            "org_unit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "anmategra_keanggotaan_org_role_id_anmategra_organization_role_id_fk": {
+          "name": "anmategra_keanggotaan_org_role_id_anmategra_organization_role_id_fk",
+          "tableFrom": "anmategra_keanggotaan",
+          "tableTo": "anmategra_organization_role",
+          "columnsFrom": [
+            "org_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_kehimpunan": {
+      "name": "anmategra_kehimpunan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lembaga_id": {
+          "name": "lembaga_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_unit_id": {
+          "name": "org_unit_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_role_id": {
+          "name": "org_role_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "division": {
+          "name": "division",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "kehimpunan_lembaga_user_unique": {
+          "name": "kehimpunan_lembaga_user_unique",
+          "columns": [
+            {
+              "expression": "lembaga_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kehimpunan_org_unit_idx": {
+          "name": "kehimpunan_org_unit_idx",
+          "columns": [
+            {
+              "expression": "org_unit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kehimpunan_org_role_idx": {
+          "name": "kehimpunan_org_role_idx",
+          "columns": [
+            {
+              "expression": "org_role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anmategra_kehimpunan_user_id_anmategra_user_id_fk": {
+          "name": "anmategra_kehimpunan_user_id_anmategra_user_id_fk",
+          "tableFrom": "anmategra_kehimpunan",
+          "tableTo": "anmategra_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "anmategra_kehimpunan_lembaga_id_anmategra_lembaga_id_fk": {
+          "name": "anmategra_kehimpunan_lembaga_id_anmategra_lembaga_id_fk",
+          "tableFrom": "anmategra_kehimpunan",
+          "tableTo": "anmategra_lembaga",
+          "columnsFrom": [
+            "lembaga_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "anmategra_kehimpunan_org_unit_id_anmategra_organization_unit_id_fk": {
+          "name": "anmategra_kehimpunan_org_unit_id_anmategra_organization_unit_id_fk",
+          "tableFrom": "anmategra_kehimpunan",
+          "tableTo": "anmategra_organization_unit",
+          "columnsFrom": [
+            "org_unit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "anmategra_kehimpunan_org_role_id_anmategra_organization_role_id_fk": {
+          "name": "anmategra_kehimpunan_org_role_id_anmategra_organization_role_id_fk",
+          "tableFrom": "anmategra_kehimpunan",
+          "tableTo": "anmategra_organization_role",
+          "columnsFrom": [
+            "org_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_lembaga": {
+      "name": "anmategra_lembaga",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "founding_date": {
+          "name": "founding_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ending_date": {
+          "name": "ending_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "lembaga_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "major": {
+          "name": "major",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field": {
+          "name": "field",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rapor_visible": {
+          "name": "rapor_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_lembaga_user_id_anmategra_user_id_fk": {
+          "name": "anmategra_lembaga_user_id_anmategra_user_id_fk",
+          "tableFrom": "anmategra_lembaga",
+          "tableTo": "anmategra_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_mahasiswa": {
+      "name": "anmategra_mahasiswa",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nim": {
+          "name": "nim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nim_tpb": {
+          "name": "nim_tpb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nama": {
+          "name": "nama",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jurusan": {
+          "name": "jurusan",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angkatan": {
+          "name": "angkatan",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "whatsapp": {
+          "name": "whatsapp",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rapor_visible": {
+          "name": "rapor_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_mahasiswa_user_id_anmategra_user_id_fk": {
+          "name": "anmategra_mahasiswa_user_id_anmategra_user_id_fk",
+          "tableFrom": "anmategra_mahasiswa",
+          "tableTo": "anmategra_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_nilai_profil_kegiatan": {
+      "name": "anmategra_nilai_profil_kegiatan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profil_id": {
+          "name": "profil_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mahasiswa_id": {
+          "name": "mahasiswa_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nilai": {
+          "name": "nilai",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "nilai_profil_kegiatan_unique": {
+          "name": "nilai_profil_kegiatan_unique",
+          "columns": [
+            {
+              "expression": "profil_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mahasiswa_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anmategra_nilai_profil_kegiatan_profil_id_anmategra_profil_kegiatan_id_fk": {
+          "name": "anmategra_nilai_profil_kegiatan_profil_id_anmategra_profil_kegiatan_id_fk",
+          "tableFrom": "anmategra_nilai_profil_kegiatan",
+          "tableTo": "anmategra_profil_kegiatan",
+          "columnsFrom": [
+            "profil_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "anmategra_nilai_profil_kegiatan_mahasiswa_id_anmategra_mahasiswa_user_id_fk": {
+          "name": "anmategra_nilai_profil_kegiatan_mahasiswa_id_anmategra_mahasiswa_user_id_fk",
+          "tableFrom": "anmategra_nilai_profil_kegiatan",
+          "tableTo": "anmategra_mahasiswa",
+          "columnsFrom": [
+            "mahasiswa_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_nilai_profil_lembaga": {
+      "name": "anmategra_nilai_profil_lembaga",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profil_id": {
+          "name": "profil_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mahasiswa_id": {
+          "name": "mahasiswa_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nilai": {
+          "name": "nilai",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "nilai_profil_lembaga_unique": {
+          "name": "nilai_profil_lembaga_unique",
+          "columns": [
+            {
+              "expression": "profil_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mahasiswa_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anmategra_nilai_profil_lembaga_profil_id_anmategra_profil_lembaga_id_fk": {
+          "name": "anmategra_nilai_profil_lembaga_profil_id_anmategra_profil_lembaga_id_fk",
+          "tableFrom": "anmategra_nilai_profil_lembaga",
+          "tableTo": "anmategra_profil_lembaga",
+          "columnsFrom": [
+            "profil_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "anmategra_nilai_profil_lembaga_mahasiswa_id_anmategra_mahasiswa_user_id_fk": {
+          "name": "anmategra_nilai_profil_lembaga_mahasiswa_id_anmategra_mahasiswa_user_id_fk",
+          "tableFrom": "anmategra_nilai_profil_lembaga",
+          "tableTo": "anmategra_mahasiswa",
+          "columnsFrom": [
+            "mahasiswa_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_notification": {
+      "name": "anmategra_notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_notification_user_id_anmategra_user_id_fk": {
+          "name": "anmategra_notification_user_id_anmategra_user_id_fk",
+          "tableFrom": "anmategra_notification",
+          "tableTo": "anmategra_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_organization_role": {
+      "name": "anmategra_organization_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "structure_id": {
+          "name": "structure_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ring_level": {
+          "name": "ring_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "organization_role_structure_idx": {
+          "name": "organization_role_structure_idx",
+          "columns": [
+            {
+              "expression": "structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anmategra_organization_role_structure_id_anmategra_organization_structure_id_fk": {
+          "name": "anmategra_organization_role_structure_id_anmategra_organization_structure_id_fk",
+          "tableFrom": "anmategra_organization_role",
+          "tableTo": "anmategra_organization_structure",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_organization_structure": {
+      "name": "anmategra_organization_structure",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lembaga_id": {
+          "name": "lembaga_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "organization_structure_active_lembaga_unique": {
+          "name": "organization_structure_active_lembaga_unique",
+          "columns": [
+            {
+              "expression": "lembaga_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anmategra_organization_structure\".\"is_active\" = true AND \"anmategra_organization_structure\".\"lembaga_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_structure_active_event_unique": {
+          "name": "organization_structure_active_event_unique",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anmategra_organization_structure\".\"is_active\" = true AND \"anmategra_organization_structure\".\"event_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anmategra_organization_structure_lembaga_id_anmategra_lembaga_id_fk": {
+          "name": "anmategra_organization_structure_lembaga_id_anmategra_lembaga_id_fk",
+          "tableFrom": "anmategra_organization_structure",
+          "tableTo": "anmategra_lembaga",
+          "columnsFrom": [
+            "lembaga_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "anmategra_organization_structure_event_id_anmategra_event_id_fk": {
+          "name": "anmategra_organization_structure_event_id_anmategra_event_id_fk",
+          "tableFrom": "anmategra_organization_structure",
+          "tableTo": "anmategra_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_organization_unit": {
+      "name": "anmategra_organization_unit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "structure_id": {
+          "name": "structure_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "organization_unit_structure_idx": {
+          "name": "organization_unit_structure_idx",
+          "columns": [
+            {
+              "expression": "structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_unit_parent_idx": {
+          "name": "organization_unit_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_unit_sibling_order_idx": {
+          "name": "organization_unit_sibling_order_idx",
+          "columns": [
+            {
+              "expression": "structure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anmategra_organization_unit_structure_id_anmategra_organization_structure_id_fk": {
+          "name": "anmategra_organization_unit_structure_id_anmategra_organization_structure_id_fk",
+          "tableFrom": "anmategra_organization_unit",
+          "tableTo": "anmategra_organization_structure",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "anmategra_organization_unit_parent_id_anmategra_organization_unit_id_fk": {
+          "name": "anmategra_organization_unit_parent_id_anmategra_organization_unit_id_fk",
+          "tableFrom": "anmategra_organization_unit",
+          "tableTo": "anmategra_organization_unit",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_pemetaan_profil_kegiatan": {
+      "name": "anmategra_pemetaan_profil_kegiatan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profil_kegiatan_id": {
+          "name": "profil_kegiatan_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profil_km_id": {
+          "name": "profil_km_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pemetaan_profil_kegiatan_profil_km_unique": {
+          "name": "pemetaan_profil_kegiatan_profil_km_unique",
+          "columns": [
+            {
+              "expression": "profil_kegiatan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profil_km_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anmategra_pemetaan_profil_kegiatan_profil_kegiatan_id_anmategra_profil_kegiatan_id_fk": {
+          "name": "anmategra_pemetaan_profil_kegiatan_profil_kegiatan_id_anmategra_profil_kegiatan_id_fk",
+          "tableFrom": "anmategra_pemetaan_profil_kegiatan",
+          "tableTo": "anmategra_profil_kegiatan",
+          "columnsFrom": [
+            "profil_kegiatan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "anmategra_pemetaan_profil_kegiatan_profil_km_id_anmategra_profil_km_id_fk": {
+          "name": "anmategra_pemetaan_profil_kegiatan_profil_km_id_anmategra_profil_km_id_fk",
+          "tableFrom": "anmategra_pemetaan_profil_kegiatan",
+          "tableTo": "anmategra_profil_km",
+          "columnsFrom": [
+            "profil_km_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_pemetaan_profil_lembaga": {
+      "name": "anmategra_pemetaan_profil_lembaga",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profil_lembaga_id": {
+          "name": "profil_lembaga_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profil_km_id": {
+          "name": "profil_km_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pemetaan_profil_lembaga_profil_km_unique": {
+          "name": "pemetaan_profil_lembaga_profil_km_unique",
+          "columns": [
+            {
+              "expression": "profil_lembaga_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profil_km_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anmategra_pemetaan_profil_lembaga_profil_lembaga_id_anmategra_profil_lembaga_id_fk": {
+          "name": "anmategra_pemetaan_profil_lembaga_profil_lembaga_id_anmategra_profil_lembaga_id_fk",
+          "tableFrom": "anmategra_pemetaan_profil_lembaga",
+          "tableTo": "anmategra_profil_lembaga",
+          "columnsFrom": [
+            "profil_lembaga_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "anmategra_pemetaan_profil_lembaga_profil_km_id_anmategra_profil_km_id_fk": {
+          "name": "anmategra_pemetaan_profil_lembaga_profil_km_id_anmategra_profil_km_id_fk",
+          "tableFrom": "anmategra_pemetaan_profil_lembaga",
+          "tableTo": "anmategra_profil_km",
+          "columnsFrom": [
+            "profil_km_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_profil_km": {
+      "name": "anmategra_profil_km",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_profil_kegiatan": {
+      "name": "anmategra_profil_kegiatan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_profil_kegiatan_event_id_anmategra_event_id_fk": {
+          "name": "anmategra_profil_kegiatan_event_id_anmategra_event_id_fk",
+          "tableFrom": "anmategra_profil_kegiatan",
+          "tableTo": "anmategra_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_profil_lembaga": {
+      "name": "anmategra_profil_lembaga",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lembaga_id": {
+          "name": "lembaga_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_profil_lembaga_lembaga_id_anmategra_lembaga_id_fk": {
+          "name": "anmategra_profil_lembaga_lembaga_id_anmategra_lembaga_id_fk",
+          "tableFrom": "anmategra_profil_lembaga",
+          "tableTo": "anmategra_lembaga",
+          "columnsFrom": [
+            "lembaga_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_session": {
+      "name": "anmategra_session",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anmategra_session_user_id_anmategra_user_id_fk": {
+          "name": "anmategra_session_user_id_anmategra_user_id_fk",
+          "tableFrom": "anmategra_session",
+          "tableTo": "anmategra_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_support": {
+      "name": "anmategra_support",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "urgent": {
+          "name": "urgent",
+          "type": "support_urgent",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Low'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "support_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Draft'"
+        },
+        "attachment": {
+          "name": "attachment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_support_user_id_anmategra_user_id_fk": {
+          "name": "anmategra_support_user_id_anmategra_user_id_fk",
+          "tableFrom": "anmategra_support",
+          "tableTo": "anmategra_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_support_reply": {
+      "name": "anmategra_support_reply",
+      "schema": "",
+      "columns": {
+        "reply_id": {
+          "name": "reply_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "support_id": {
+          "name": "support_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_support_reply_user_id_anmategra_user_id_fk": {
+          "name": "anmategra_support_reply_user_id_anmategra_user_id_fk",
+          "tableFrom": "anmategra_support_reply",
+          "tableTo": "anmategra_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "anmategra_support_reply_support_id_anmategra_support_id_fk": {
+          "name": "anmategra_support_reply_support_id_anmategra_support_id_fk",
+          "tableFrom": "anmategra_support_reply",
+          "tableTo": "anmategra_support",
+          "columnsFrom": [
+            "support_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_user": {
+      "name": "anmategra_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mahasiswa'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "anmategra_user_email_unique": {
+          "name": "anmategra_user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    },
+    "public.anmategra_verification_token": {
+      "name": "anmategra_verification_token",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "anmategra_verification_token_identifier_token_pk": {
+          "name": "anmategra_verification_token_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_verified_user": {
+      "name": "anmategra_verified_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.association_request_status": {
+      "name": "association_request_status",
+      "schema": "public",
+      "values": [
+        "Pending",
+        "Accepted",
+        "Declined"
+      ]
+    },
+    "public.event_status": {
+      "name": "event_status",
+      "schema": "public",
+      "values": [
+        "Coming Soon",
+        "On going",
+        "Ended"
+      ]
+    },
+    "public.lembaga_type": {
+      "name": "lembaga_type",
+      "schema": "public",
+      "values": [
+        "Himpunan",
+        "UKM",
+        "Kepanitiaan",
+        "BSO"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "Association Request",
+        "System"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "lembaga",
+        "mahasiswa"
+      ]
+    },
+    "public.support_status": {
+      "name": "support_status",
+      "schema": "public",
+      "values": [
+        "Open",
+        "In Progress",
+        "Resolved",
+        "Closed",
+        "Draft",
+        "Backlog",
+        "Reported"
+      ]
+    },
+    "public.support_urgent": {
+      "name": "support_urgent",
+      "schema": "public",
+      "values": [
+        "Low",
+        "Medium",
+        "High"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1786396556997,
       "tag": "0023_marvelous_robin_chapel",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1786547787858,
+      "tag": "0024_overrated_steve_rogers",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -6,6 +6,7 @@ import { eventRouter } from './routers/event';
 import { kegiatanRouter } from './routers/kegiatan';
 import { landingRouter } from './routers/landing';
 import { lembagaRouter } from './routers/lembaga';
+import { organizationRouter } from './routers/organization';
 import { profilRouter } from './routers/profil';
 import { raporRouter } from './routers/rapor';
 import { userRouter } from './routers/user';
@@ -25,6 +26,7 @@ export const appRouter = createTRPCRouter({
   users: userRouter,
   profil: profilRouter,
   rapor: raporRouter,
+  organization: organizationRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/event/update.ts
+++ b/src/server/api/routers/event/update.ts
@@ -20,6 +20,7 @@ import {
   UpdateEventInputSchema,
   UpdateEventOutputSchema,
 } from '../../types/event.type';
+import { resolveOrgAssignment } from '../organization/services';
 
 export const updateEvent = lembagaProcedure
   .input(UpdateEventInputSchema)
@@ -98,12 +99,21 @@ export const addNewPanitia = lembagaProcedure
         });
       }
 
+      const assignment = await resolveOrgAssignment(ctx.db, {
+        ownerType: 'event',
+        ownerId: input.event_id,
+        org_unit_id: input.org_unit_id,
+        org_role_id: input.org_role_id,
+      });
+
       await ctx.db.insert(keanggotaan).values({
         id: input.event_id + '_' + input.user_id,
         event_id: input.event_id,
         user_id: input.user_id,
-        position: input.position,
-        division: input.division,
+        org_unit_id: assignment.org_unit_id,
+        org_role_id: assignment.org_role_id,
+        position: assignment.position ?? input.position,
+        division: assignment.division ?? input.division,
       });
 
       return {
@@ -204,11 +214,24 @@ export const editPanitia = lembagaProcedure
         });
       }
 
+      const hasOrgAssignmentInput =
+        input.org_unit_id !== undefined || input.org_role_id !== undefined;
+      const assignment = await resolveOrgAssignment(ctx.db, {
+        ownerType: 'event',
+        ownerId: input.event_id,
+        org_unit_id: input.org_unit_id,
+        org_role_id: input.org_role_id,
+      });
+
       const result = await ctx.db
         .update(keanggotaan)
         .set({
-          position: input.position,
-          division: input.division,
+          ...(hasOrgAssignmentInput && {
+            org_unit_id: assignment.org_unit_id,
+            org_role_id: assignment.org_role_id,
+          }),
+          position: assignment.position ?? input.position,
+          division: assignment.division ?? input.division,
         })
         .where(
           and(
@@ -263,6 +286,13 @@ export const addNewPanitiaManual = lembagaProcedure
         });
       }
 
+      const assignment = await resolveOrgAssignment(ctx.db, {
+        ownerType: 'event',
+        ownerId: input.event_id,
+        org_unit_id: input.org_unit_id,
+        org_role_id: input.org_role_id,
+      });
+
       // Check if user already exists by email (primary identifier)
       const email = `${input.nim}@mahasiswa.itb.ac.id`;
       const existingUser = await ctx.db.query.users.findFirst({
@@ -282,8 +312,10 @@ export const addNewPanitiaManual = lembagaProcedure
           id: input.event_id + '_' + existingUser.id,
           event_id: input.event_id,
           user_id: existingUser.id,
-          position: input.position,
-          division: input.division,
+          org_unit_id: assignment.org_unit_id,
+          org_role_id: assignment.org_role_id,
+          position: assignment.position ?? input.position,
+          division: assignment.division ?? input.division,
         });
 
         return {
@@ -322,8 +354,10 @@ export const addNewPanitiaManual = lembagaProcedure
           id: input.event_id + '_' + user[0]!.id,
           event_id: input.event_id,
           user_id: user[0]!.id,
-          position: input.position,
-          division: input.division,
+          org_unit_id: assignment.org_unit_id,
+          org_role_id: assignment.org_role_id,
+          position: assignment.position ?? input.position,
+          division: assignment.division ?? input.division,
         });
       });
 

--- a/src/server/api/routers/lembaga.ts
+++ b/src/server/api/routers/lembaga.ts
@@ -431,6 +431,20 @@ export const lembagaRouter = createTRPCRouter({
           success: true,
         };
       } catch (error) {
+        if (error instanceof TRPCError) {
+          throw error;
+        }
+        if (
+          error &&
+          typeof error === 'object' &&
+          'code' in error &&
+          error.code === '23505'
+        ) {
+          throw new TRPCError({
+            code: 'CONFLICT',
+            message: 'Mahasiswa tersebut sudah terdaftar sebagai anggota.',
+          });
+        }
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',
           message: 'Gagal menambahkan anggota',
@@ -509,6 +523,22 @@ export const lembagaRouter = createTRPCRouter({
           success: true,
         };
       } catch (error) {
+        // TRPCError extends Error, so this must stay above the `instanceof Error`
+        // branch below — otherwise every thrown code is downgraded to a 500.
+        if (error instanceof TRPCError) {
+          throw error;
+        }
+        if (
+          error &&
+          typeof error === 'object' &&
+          'code' in error &&
+          error.code === '23505'
+        ) {
+          throw new TRPCError({
+            code: 'CONFLICT',
+            message: 'Mahasiswa tersebut sudah terdaftar sebagai anggota.',
+          });
+        }
         if (error instanceof Error) {
           throw new TRPCError({
             code: 'INTERNAL_SERVER_ERROR',

--- a/src/server/api/routers/lembaga.ts
+++ b/src/server/api/routers/lembaga.ts
@@ -95,6 +95,7 @@ import {
   editAnggotaLembagaInputSchema,
   editAnggotaLembagaOutputSchema,
 } from '../types/lembaga.type';
+import { resolveOrgAssignment } from './organization/services';
 
 export const lembagaRouter = createTRPCRouter({
   // Fetch lembaga general information
@@ -419,12 +420,21 @@ export const lembagaRouter = createTRPCRouter({
     .output(AddAnggotaLembagaOutputSchema)
     .mutation(async ({ ctx, input }) => {
       try {
+        const assignment = await resolveOrgAssignment(ctx.db, {
+          ownerType: 'lembaga',
+          ownerId: ctx.session.user.lembagaId!,
+          org_unit_id: input.org_unit_id,
+          org_role_id: input.org_role_id,
+        });
+
         await ctx.db.insert(kehimpunan).values({
           id: input.user_id + '_' + ctx.session.user.id,
           lembagaId: ctx.session.user.lembagaId!,
           userId: input.user_id,
-          division: input.division,
-          position: input.position,
+          org_unit_id: assignment.org_unit_id,
+          org_role_id: assignment.org_role_id,
+          division: assignment.division ?? input.division,
+          position: assignment.position ?? input.position,
         });
 
         return {
@@ -457,6 +467,13 @@ export const lembagaRouter = createTRPCRouter({
     .output(AddAnggotaLembagaOutputSchema)
     .mutation(async ({ ctx, input }) => {
       try {
+        const assignment = await resolveOrgAssignment(ctx.db, {
+          ownerType: 'lembaga',
+          ownerId: ctx.session.user.lembagaId!,
+          org_unit_id: input.org_unit_id,
+          org_role_id: input.org_role_id,
+        });
+
         // Check if user already exists by email (primary identifier)
         const email = `${input.nim}@mahasiswa.itb.ac.id`;
         const existingUser = await ctx.db.query.users.findFirst({
@@ -477,8 +494,10 @@ export const lembagaRouter = createTRPCRouter({
             id: existingUser.id + '_' + ctx.session.user.id,
             lembagaId: ctx.session.user.lembagaId!,
             userId: existingUser.id,
-            division: input.division,
-            position: input.position,
+            org_unit_id: assignment.org_unit_id,
+            org_role_id: assignment.org_role_id,
+            division: assignment.division ?? input.division,
+            position: assignment.position ?? input.position,
           });
 
           return { success: true };
@@ -514,8 +533,10 @@ export const lembagaRouter = createTRPCRouter({
             id: user[0]!.id + '_' + ctx.session.user.id,
             lembagaId: ctx.session.user.lembagaId!,
             userId: user[0]!.id,
-            division: input.division,
-            position: input.position,
+            org_unit_id: assignment.org_unit_id,
+            org_role_id: assignment.org_role_id,
+            division: assignment.division ?? input.division,
+            position: assignment.position ?? input.position,
           });
         });
 
@@ -589,11 +610,24 @@ export const lembagaRouter = createTRPCRouter({
     .output(editAnggotaLembagaOutputSchema)
     .mutation(async ({ ctx, input }) => {
       try {
+        const hasOrgAssignmentInput =
+          input.org_unit_id !== undefined || input.org_role_id !== undefined;
+        const assignment = await resolveOrgAssignment(ctx.db, {
+          ownerType: 'lembaga',
+          ownerId: ctx.session.user.lembagaId!,
+          org_unit_id: input.org_unit_id,
+          org_role_id: input.org_role_id,
+        });
+
         const updated = await ctx.db
           .update(kehimpunan)
           .set({
-            position: input.position,
-            division: input.division,
+            ...(hasOrgAssignmentInput && {
+              org_unit_id: assignment.org_unit_id,
+              org_role_id: assignment.org_role_id,
+            }),
+            position: assignment.position ?? input.position,
+            division: assignment.division ?? input.division,
           })
           .where(
             and(

--- a/src/server/api/routers/organization/assignment.ts
+++ b/src/server/api/routers/organization/assignment.ts
@@ -1,8 +1,196 @@
-import { createTRPCRouter } from '~/server/api/trpc';
+import { TRPCError } from '@trpc/server';
+import { and, eq } from 'drizzle-orm';
+import { createTRPCRouter, lembagaProcedure } from '~/server/api/trpc';
+import {
+  AssignAnggotaLembagaOrganizationInputSchema,
+  AssignAnggotaLembagaOrganizationOutputSchema,
+  AssignPanitiaKegiatanOrganizationInputSchema,
+  AssignPanitiaKegiatanOrganizationOutputSchema,
+  UnassignAnggotaLembagaOrganizationInputSchema,
+  UnassignAnggotaLembagaOrganizationOutputSchema,
+  UnassignPanitiaKegiatanOrganizationInputSchema,
+  UnassignPanitiaKegiatanOrganizationOutputSchema,
+} from '~/server/api/types/organization.type';
+import { keanggotaan, kehimpunan } from '~/server/db/schema';
 
-/**
- * SO-03 Fase 6 — penugasan anggota ke unit/posisi.
- * assignAnggotaLembaga / unassignAnggotaLembaga
- * assignPanitiaKegiatan / unassignPanitiaKegiatan
- */
-export const organizationAssignmentRouter = createTRPCRouter({});
+import { validateKegiatanOwnership } from '../profil/services';
+import { resolveOrgAssignment } from './services';
+
+function getSessionLembagaId(lembagaId: string | undefined) {
+  if (!lembagaId) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Akun ini tidak terhubung ke lembaga mana pun.',
+    });
+  }
+  return lembagaId;
+}
+
+function assertUpdated(rows: unknown[], message: string) {
+  if (rows.length === 0) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message,
+    });
+  }
+}
+
+export const organizationAssignmentRouter = createTRPCRouter({
+  assignAnggotaLembaga: lembagaProcedure
+    .input(AssignAnggotaLembagaOrganizationInputSchema)
+    .output(AssignAnggotaLembagaOrganizationOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const lembagaId = getSessionLembagaId(ctx.session.user.lembagaId);
+
+      try {
+        const assignment = await resolveOrgAssignment(ctx.db, {
+          ownerType: 'lembaga',
+          ownerId: lembagaId,
+          org_unit_id: input.org_unit_id,
+          org_role_id: input.org_role_id,
+        });
+
+        const updated = await ctx.db
+          .update(kehimpunan)
+          .set({
+            org_unit_id: assignment.org_unit_id,
+            org_role_id: assignment.org_role_id,
+            ...(assignment.division !== undefined && {
+              division: assignment.division,
+            }),
+            ...(assignment.position !== undefined && {
+              position: assignment.position,
+            }),
+          })
+          .where(
+            and(
+              eq(kehimpunan.lembagaId, lembagaId),
+              eq(kehimpunan.userId, input.user_id),
+            ),
+          )
+          .returning({ id: kehimpunan.id });
+
+        assertUpdated(updated, 'Anggota lembaga tidak ditemukan.');
+
+        return { success: true };
+      } catch (error) {
+        if (error instanceof TRPCError) throw error;
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Gagal menugaskan anggota ke struktur organisasi.',
+        });
+      }
+    }),
+
+  unassignAnggotaLembaga: lembagaProcedure
+    .input(UnassignAnggotaLembagaOrganizationInputSchema)
+    .output(UnassignAnggotaLembagaOrganizationOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const lembagaId = getSessionLembagaId(ctx.session.user.lembagaId);
+
+      try {
+        const updated = await ctx.db
+          .update(kehimpunan)
+          .set({
+            org_unit_id: null,
+            org_role_id: null,
+          })
+          .where(
+            and(
+              eq(kehimpunan.lembagaId, lembagaId),
+              eq(kehimpunan.userId, input.user_id),
+            ),
+          )
+          .returning({ id: kehimpunan.id });
+
+        assertUpdated(updated, 'Anggota lembaga tidak ditemukan.');
+
+        return { success: true };
+      } catch (error) {
+        if (error instanceof TRPCError) throw error;
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Gagal menghapus penugasan anggota lembaga.',
+        });
+      }
+    }),
+
+  assignPanitiaKegiatan: lembagaProcedure
+    .input(AssignPanitiaKegiatanOrganizationInputSchema)
+    .output(AssignPanitiaKegiatanOrganizationOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        await validateKegiatanOwnership(ctx, input.event_id);
+
+        const assignment = await resolveOrgAssignment(ctx.db, {
+          ownerType: 'event',
+          ownerId: input.event_id,
+          org_unit_id: input.org_unit_id,
+          org_role_id: input.org_role_id,
+        });
+
+        const updated = await ctx.db
+          .update(keanggotaan)
+          .set({
+            org_unit_id: assignment.org_unit_id,
+            org_role_id: assignment.org_role_id,
+            ...(assignment.division !== undefined && {
+              division: assignment.division,
+            }),
+            ...(assignment.position !== undefined && {
+              position: assignment.position,
+            }),
+          })
+          .where(
+            and(
+              eq(keanggotaan.event_id, input.event_id),
+              eq(keanggotaan.user_id, input.user_id),
+            ),
+          )
+          .returning({ id: keanggotaan.id });
+
+        assertUpdated(updated, 'Panitia kegiatan tidak ditemukan.');
+
+        return { success: true };
+      } catch (error) {
+        if (error instanceof TRPCError) throw error;
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Gagal menugaskan panitia ke struktur organisasi.',
+        });
+      }
+    }),
+
+  unassignPanitiaKegiatan: lembagaProcedure
+    .input(UnassignPanitiaKegiatanOrganizationInputSchema)
+    .output(UnassignPanitiaKegiatanOrganizationOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        await validateKegiatanOwnership(ctx, input.event_id);
+
+        const updated = await ctx.db
+          .update(keanggotaan)
+          .set({
+            org_unit_id: null,
+            org_role_id: null,
+          })
+          .where(
+            and(
+              eq(keanggotaan.event_id, input.event_id),
+              eq(keanggotaan.user_id, input.user_id),
+            ),
+          )
+          .returning({ id: keanggotaan.id });
+
+        assertUpdated(updated, 'Panitia kegiatan tidak ditemukan.');
+
+        return { success: true };
+      } catch (error) {
+        if (error instanceof TRPCError) throw error;
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Gagal menghapus penugasan panitia kegiatan.',
+        });
+      }
+    }),
+});

--- a/src/server/api/routers/organization/assignment.ts
+++ b/src/server/api/routers/organization/assignment.ts
@@ -1,0 +1,8 @@
+import { createTRPCRouter } from '~/server/api/trpc';
+
+/**
+ * SO-03 Fase 6 — penugasan anggota ke unit/posisi.
+ * assignAnggotaLembaga / unassignAnggotaLembaga
+ * assignPanitiaKegiatan / unassignPanitiaKegiatan
+ */
+export const organizationAssignmentRouter = createTRPCRouter({});

--- a/src/server/api/routers/organization/index.ts
+++ b/src/server/api/routers/organization/index.ts
@@ -1,0 +1,19 @@
+import { createTRPCRouter } from '~/server/api/trpc';
+
+import { organizationAssignmentRouter } from './assignment';
+import { organizationRoleRouter } from './role';
+import { organizationStructureRouter } from './structure';
+import { organizationUnitRouter } from './unit';
+
+/**
+ * Nested rather than flattened: `create` exists on three of these, so merging
+ * them into one namespace would collide. Plain `createTRPCRouter` composition —
+ * `mergeTRPCRouters` is for flattening whole routers onto one namespace, which
+ * is not what we want here.
+ */
+export const organizationRouter = createTRPCRouter({
+  structure: organizationStructureRouter,
+  unit: organizationUnitRouter,
+  role: organizationRoleRouter,
+  assignment: organizationAssignmentRouter,
+});

--- a/src/server/api/routers/organization/role.ts
+++ b/src/server/api/routers/organization/role.ts
@@ -1,0 +1,7 @@
+import { createTRPCRouter } from '~/server/api/trpc';
+
+/**
+ * SO-03 Fase 5 — CRUD posisi.
+ * create / update / reorder / delete / getAll
+ */
+export const organizationRoleRouter = createTRPCRouter({});

--- a/src/server/api/routers/organization/role.ts
+++ b/src/server/api/routers/organization/role.ts
@@ -1,7 +1,225 @@
-import { createTRPCRouter } from '~/server/api/trpc';
+import { TRPCError } from '@trpc/server';
+import { and, eq, max } from 'drizzle-orm';
+import { createTRPCRouter, lembagaProcedure } from '~/server/api/trpc';
+import {
+  CreateOrganizationRoleInputSchema,
+  CreateOrganizationRoleOutputSchema,
+  DeleteOrganizationRoleInputSchema,
+  DeleteOrganizationRoleOutputSchema,
+  GetAllOrganizationRoleInputSchema,
+  GetAllOrganizationRoleOutputSchema,
+  ReorderOrganizationRoleInputSchema,
+  ReorderOrganizationRoleOutputSchema,
+  UpdateOrganizationRoleInputSchema,
+  UpdateOrganizationRoleOutputSchema,
+} from '~/server/api/types/organization.type';
+import { keanggotaan, kehimpunan, organizationRole } from '~/server/db/schema';
 
-/**
- * SO-03 Fase 5 — CRUD posisi.
- * create / update / reorder / delete / getAll
- */
-export const organizationRoleRouter = createTRPCRouter({});
+import {
+  type StructureOwner,
+  assertExactSiblingSet,
+  countMembersReferencing,
+  isForeignKeyViolation,
+  resolveRoleOwnership,
+  resolveStructureOwnership,
+} from './services';
+
+const ROLE_COLUMNS = {
+  id: organizationRole.id,
+  structure_id: organizationRole.structure_id,
+  name: organizationRole.name,
+  ring_level: organizationRole.ring_level,
+  sort_order: organizationRole.sort_order,
+};
+
+type Db = Parameters<typeof countMembersReferencing>[0];
+
+function loadStructureRoles(db: Db, structureId: string) {
+  return db
+    .select(ROLE_COLUMNS)
+    .from(organizationRole)
+    .where(eq(organizationRole.structure_id, structureId))
+    .orderBy(
+      organizationRole.ring_level,
+      organizationRole.sort_order,
+      organizationRole.name,
+    );
+}
+
+async function nextSortOrder(db: Db, structureId: string): Promise<number> {
+  const rows = await db
+    .select({ value: max(organizationRole.sort_order) })
+    .from(organizationRole)
+    .where(eq(organizationRole.structure_id, structureId));
+
+  return (rows[0]?.value ?? -1) + 1;
+}
+
+/** Keeps the denormalized `position` text on member rows in step with a rename. */
+async function propagateRoleName(
+  tx: Db,
+  structure: StructureOwner,
+  roleId: string,
+  name: string,
+) {
+  if (structure.lembagaId) {
+    await tx
+      .update(kehimpunan)
+      .set({ position: name })
+      .where(
+        and(
+          eq(kehimpunan.lembagaId, structure.lembagaId),
+          eq(kehimpunan.org_role_id, roleId),
+        ),
+      );
+    return;
+  }
+
+  if (structure.eventId) {
+    await tx
+      .update(keanggotaan)
+      .set({ position: name })
+      .where(
+        and(
+          eq(keanggotaan.event_id, structure.eventId),
+          eq(keanggotaan.org_role_id, roleId),
+        ),
+      );
+  }
+}
+
+export const organizationRoleRouter = createTRPCRouter({
+  create: lembagaProcedure
+    .input(CreateOrganizationRoleInputSchema)
+    .output(CreateOrganizationRoleOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      await resolveStructureOwnership(ctx, input.structure_id);
+
+      const roleId = await ctx.db.transaction(async (tx) => {
+        const sortOrder = await nextSortOrder(tx, input.structure_id);
+        const rows = await tx
+          .insert(organizationRole)
+          .values({
+            structure_id: input.structure_id,
+            name: input.name,
+            ring_level: input.ring_level,
+            sort_order: sortOrder,
+          })
+          .returning({ id: organizationRole.id });
+
+        return rows[0]!.id;
+      });
+
+      return { success: true, role_id: roleId };
+    }),
+
+  update: lembagaProcedure
+    .input(UpdateOrganizationRoleInputSchema)
+    .output(UpdateOrganizationRoleOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { structure } = await resolveRoleOwnership(ctx, input.role_id);
+
+      if (input.name === undefined && input.ring_level === undefined) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Tidak ada perubahan yang dikirim.',
+        });
+      }
+
+      await ctx.db.transaction(async (tx) => {
+        await tx
+          .update(organizationRole)
+          .set({
+            ...(input.name !== undefined && { name: input.name }),
+            ...(input.ring_level !== undefined && {
+              ring_level: input.ring_level,
+            }),
+          })
+          .where(eq(organizationRole.id, input.role_id));
+
+        if (input.name !== undefined) {
+          // UPDATE only — the member_count triggers fire on INSERT/DELETE, so
+          // counts stay untouched.
+          await propagateRoleName(tx, structure, input.role_id, input.name);
+        }
+      });
+
+      return { success: true };
+    }),
+
+  reorder: lembagaProcedure
+    .input(ReorderOrganizationRoleInputSchema)
+    .output(ReorderOrganizationRoleOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      await resolveStructureOwnership(ctx, input.structure_id);
+      await assertExactSiblingSet(
+        ctx.db,
+        'role',
+        input.structure_id,
+        null,
+        input.role_ids,
+      );
+
+      await ctx.db.transaction(async (tx) => {
+        for (const [i, id] of input.role_ids.entries()) {
+          await tx
+            .update(organizationRole)
+            .set({ sort_order: i })
+            .where(eq(organizationRole.id, id));
+        }
+      });
+
+      return { success: true };
+    }),
+
+  delete: lembagaProcedure
+    .input(DeleteOrganizationRoleInputSchema)
+    .output(DeleteOrganizationRoleOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { structure } = await resolveRoleOwnership(ctx, input.role_id);
+
+      const members = await countMembersReferencing(
+        ctx.db,
+        structure,
+        'org_role_id',
+        input.role_id,
+      );
+      if (members > 0) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: `Masih ada ${members} anggota yang ditugaskan pada posisi ini.`,
+        });
+      }
+
+      try {
+        await ctx.db
+          .delete(organizationRole)
+          .where(eq(organizationRole.id, input.role_id));
+      } catch (error) {
+        if (error instanceof TRPCError) throw error;
+        if (isForeignKeyViolation(error)) {
+          throw new TRPCError({
+            code: 'CONFLICT',
+            message: 'Posisi masih direferensikan oleh data lain.',
+          });
+        }
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Gagal menghapus posisi.',
+        });
+      }
+
+      return { success: true };
+    }),
+
+  getAll: lembagaProcedure
+    .input(GetAllOrganizationRoleInputSchema)
+    .output(GetAllOrganizationRoleOutputSchema)
+    .query(async ({ ctx, input }) => {
+      await resolveStructureOwnership(ctx, input.structure_id);
+
+      const roles = await loadStructureRoles(ctx.db, input.structure_id);
+
+      return { roles };
+    }),
+});

--- a/src/server/api/routers/organization/services.ts
+++ b/src/server/api/routers/organization/services.ts
@@ -32,12 +32,50 @@ export const ORG_UNIT_KIND_RANK: Record<OrganizationUnitKind, number> = {
   Subdivisi: 3,
 };
 
-export type StructureOwner = {
-  id: string;
-  lembagaId: string | null;
-  eventId: string | null;
-  is_active: boolean;
-};
+export type StructureOwner = typeof organizationStructure.$inferSelect;
+
+/** Postgres unique_violation — a duplicate that callers should see as CONFLICT. */
+export function isUniqueViolation(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === 'object' &&
+    'code' in error &&
+    (error as { code?: string }).code === '23505'
+  );
+}
+
+/** Postgres foreign_key_violation — e.g. deleting a unit that still has children. */
+export function isForeignKeyViolation(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === 'object' &&
+    'code' in error &&
+    (error as { code?: string }).code === '23503'
+  );
+}
+
+/**
+ * Resolves which owner a request is scoped to. `event_id` present means the
+ * structure hangs off that kegiatan (ownership checked); absent means it
+ * belongs to the caller's own lembaga — taken from the session, never input.
+ */
+export async function resolveOwnerScope(
+  ctx: TRPCContext,
+  eventId?: string,
+): Promise<{ lembagaId: string | null; eventId: string | null }> {
+  if (eventId) {
+    await validateKegiatanOwnership(ctx, eventId);
+    return { lembagaId: null, eventId };
+  }
+  const lembagaId = ctx.session?.user?.lembagaId;
+  if (!lembagaId) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Akun ini tidak terhubung ke lembaga mana pun.',
+    });
+  }
+  return { lembagaId, eventId: null };
+}
 
 /**
  * `lembagaProcedure` only proves "you are some lembaga". Every structure-scoped
@@ -68,12 +106,7 @@ export async function resolveStructureOwnership(
   structureId: string,
 ): Promise<StructureOwner> {
   const rows = await ctx.db
-    .select({
-      id: organizationStructure.id,
-      lembagaId: organizationStructure.lembagaId,
-      eventId: organizationStructure.eventId,
-      is_active: organizationStructure.is_active,
-    })
+    .select()
     .from(organizationStructure)
     .where(eq(organizationStructure.id, structureId))
     .limit(1);
@@ -100,12 +133,7 @@ export async function resolveUnitOwnership(
   const rows = await ctx.db
     .select({
       unit: organizationUnit,
-      structure: {
-        id: organizationStructure.id,
-        lembagaId: organizationStructure.lembagaId,
-        eventId: organizationStructure.eventId,
-        is_active: organizationStructure.is_active,
-      },
+      structure: organizationStructure,
     })
     .from(organizationUnit)
     .innerJoin(
@@ -134,12 +162,7 @@ export async function resolveRoleOwnership(
   const rows = await ctx.db
     .select({
       role: organizationRole,
-      structure: {
-        id: organizationStructure.id,
-        lembagaId: organizationStructure.lembagaId,
-        eventId: organizationStructure.eventId,
-        is_active: organizationStructure.is_active,
-      },
+      structure: organizationStructure,
     })
     .from(organizationRole)
     .innerJoin(

--- a/src/server/api/routers/organization/services.ts
+++ b/src/server/api/routers/organization/services.ts
@@ -1,0 +1,502 @@
+import { TRPCError } from '@trpc/server';
+import type { inferAsyncReturnType } from '@trpc/server';
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import { type createTRPCContext } from '~/server/api/trpc';
+import {
+  type OrganizationUnitKind,
+  keanggotaan,
+  kehimpunan,
+  organizationRole,
+  organizationStructure,
+  organizationUnit,
+} from '~/server/db/schema';
+
+import {
+  validateKegiatanOwnership,
+  validateLembagaOwnership,
+} from '../profil/services';
+
+type TRPCContext = inferAsyncReturnType<typeof createTRPCContext>;
+type Db = TRPCContext['db'];
+
+export const ORGANIZATION_UNIT_MAX_LEVEL = 3;
+
+/**
+ * Hierarchy ordering. A child's kind must rank strictly BELOW its parent's.
+ * A root may carry any kind — production data has flat structures where
+ * `Divisi` sits at the root with no `Bidang` above it.
+ */
+export const ORG_UNIT_KIND_RANK: Record<OrganizationUnitKind, number> = {
+  Bidang: 1,
+  Divisi: 2,
+  Subdivisi: 3,
+};
+
+export type StructureOwner = {
+  id: string;
+  lembagaId: string | null;
+  eventId: string | null;
+  is_active: boolean;
+};
+
+/**
+ * `lembagaProcedure` only proves "you are some lembaga". Every structure-scoped
+ * operation must additionally prove it owns the structure — either directly, or
+ * through the event the structure hangs off.
+ */
+async function assertStructureOwnership(
+  ctx: TRPCContext,
+  structure: StructureOwner,
+) {
+  if (structure.lembagaId) {
+    await validateLembagaOwnership(ctx, structure.lembagaId);
+    return;
+  }
+  if (structure.eventId) {
+    await validateKegiatanOwnership(ctx, structure.eventId);
+    return;
+  }
+  // organization_structure_owner_xor makes this unreachable through SQL.
+  throw new TRPCError({
+    code: 'INTERNAL_SERVER_ERROR',
+    message: 'Struktur organisasi tidak memiliki pemilik yang valid.',
+  });
+}
+
+export async function resolveStructureOwnership(
+  ctx: TRPCContext,
+  structureId: string,
+): Promise<StructureOwner> {
+  const rows = await ctx.db
+    .select({
+      id: organizationStructure.id,
+      lembagaId: organizationStructure.lembagaId,
+      eventId: organizationStructure.eventId,
+      is_active: organizationStructure.is_active,
+    })
+    .from(organizationStructure)
+    .where(eq(organizationStructure.id, structureId))
+    .limit(1);
+
+  const structure = rows[0];
+  if (!structure) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: 'Struktur organisasi tidak ditemukan.',
+    });
+  }
+
+  await assertStructureOwnership(ctx, structure);
+  return structure;
+}
+
+export type OwnedUnit = typeof organizationUnit.$inferSelect;
+export type OwnedRole = typeof organizationRole.$inferSelect;
+
+export async function resolveUnitOwnership(
+  ctx: TRPCContext,
+  unitIdValue: string,
+): Promise<{ unit: OwnedUnit; structure: StructureOwner }> {
+  const rows = await ctx.db
+    .select({
+      unit: organizationUnit,
+      structure: {
+        id: organizationStructure.id,
+        lembagaId: organizationStructure.lembagaId,
+        eventId: organizationStructure.eventId,
+        is_active: organizationStructure.is_active,
+      },
+    })
+    .from(organizationUnit)
+    .innerJoin(
+      organizationStructure,
+      eq(organizationUnit.structure_id, organizationStructure.id),
+    )
+    .where(eq(organizationUnit.id, unitIdValue))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: 'Unit tidak ditemukan.',
+    });
+  }
+
+  await assertStructureOwnership(ctx, row.structure);
+  return row;
+}
+
+export async function resolveRoleOwnership(
+  ctx: TRPCContext,
+  roleIdValue: string,
+): Promise<{ role: OwnedRole; structure: StructureOwner }> {
+  const rows = await ctx.db
+    .select({
+      role: organizationRole,
+      structure: {
+        id: organizationStructure.id,
+        lembagaId: organizationStructure.lembagaId,
+        eventId: organizationStructure.eventId,
+        is_active: organizationStructure.is_active,
+      },
+    })
+    .from(organizationRole)
+    .innerJoin(
+      organizationStructure,
+      eq(organizationRole.structure_id, organizationStructure.id),
+    )
+    .where(eq(organizationRole.id, roleIdValue))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: 'Posisi tidak ditemukan.',
+    });
+  }
+
+  await assertStructureOwnership(ctx, row.structure);
+  return row;
+}
+
+/**
+ * Validates a prospective parent for a unit of `childKind`, and returns the
+ * level the child must sit at. A null parent means the child becomes a root.
+ */
+export function resolveParentPlacement(
+  childKind: OrganizationUnitKind,
+  parent: Pick<OwnedUnit, 'id' | 'kind' | 'level' | 'structure_id'> | null,
+  structureId: string,
+): number {
+  if (!parent) return 1;
+
+  if (parent.structure_id !== structureId) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Induk harus berada di struktur organisasi yang sama.',
+    });
+  }
+
+  if (ORG_UNIT_KIND_RANK[childKind] <= ORG_UNIT_KIND_RANK[parent.kind]) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `${childKind} tidak boleh berada di bawah ${parent.kind}.`,
+    });
+  }
+
+  const level = parent.level + 1;
+  if (level > ORGANIZATION_UNIT_MAX_LEVEL) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `Struktur maksimal ${ORGANIZATION_UNIT_MAX_LEVEL} tingkat.`,
+    });
+  }
+  return level;
+}
+
+export type FlatUnit = Pick<
+  OwnedUnit,
+  'id' | 'structure_id' | 'parent_id' | 'name' | 'kind' | 'level' | 'sort_order'
+>;
+
+export type UnitTreeNode = FlatUnit & {
+  member_count: number;
+  children: UnitTreeNode[];
+};
+
+/**
+ * Builds the nested tree from a flat, already-ordered unit list in one pass.
+ *
+ * Flat query + assemble in JS beats a nested relational query here: depth is
+ * capped at 3, row counts per structure are small, and this leaves an obvious
+ * place to attach member counts, which a json-agg query does not.
+ */
+export function buildUnitTree(
+  units: FlatUnit[],
+  memberCounts: Map<string, number>,
+): UnitTreeNode[] {
+  const nodes = new Map<string, UnitTreeNode>();
+  for (const u of units) {
+    nodes.set(u.id, {
+      ...u,
+      member_count: memberCounts.get(u.id) ?? 0,
+      children: [],
+    });
+  }
+
+  const roots: UnitTreeNode[] = [];
+  for (const u of units) {
+    const node = nodes.get(u.id)!;
+    const parent = u.parent_id ? nodes.get(u.parent_id) : undefined;
+    // A parent outside this list would orphan the node; treat it as a root so
+    // nothing silently disappears from the response.
+    if (parent) parent.children.push(node);
+    else roots.push(node);
+  }
+  return roots;
+}
+
+/** "Bidang Internal / Divisi SDM" — for flat dropdown labels. */
+export function buildPathLabels(units: FlatUnit[]): Map<string, string> {
+  const byId = new Map(units.map((u) => [u.id, u]));
+  const labels = new Map<string, string>();
+  for (const u of units) {
+    const parts: string[] = [];
+    let cur: FlatUnit | undefined = u;
+    // Depth is capped at 3; the guard is a cycle backstop, not a real limit.
+    for (let i = 0; cur && i <= ORGANIZATION_UNIT_MAX_LEVEL; i++) {
+      parts.unshift(cur.name);
+      cur = cur.parent_id ? byId.get(cur.parent_id) : undefined;
+    }
+    labels.set(u.id, parts.join(' / '));
+  }
+  return labels;
+}
+
+export async function countMembersByUnit(
+  db: Db,
+  structure: StructureOwner,
+): Promise<Map<string, number>> {
+  const rows = structure.lembagaId
+    ? await db
+        .select({
+          unitId: kehimpunan.org_unit_id,
+          n: sql<number>`count(*)::int`,
+        })
+        .from(kehimpunan)
+        .where(eq(kehimpunan.lembagaId, structure.lembagaId))
+        .groupBy(kehimpunan.org_unit_id)
+    : await db
+        .select({
+          unitId: keanggotaan.org_unit_id,
+          n: sql<number>`count(*)::int`,
+        })
+        .from(keanggotaan)
+        .where(eq(keanggotaan.event_id, structure.eventId!))
+        .groupBy(keanggotaan.org_unit_id);
+
+  const counts = new Map<string, number>();
+  for (const r of rows) if (r.unitId) counts.set(r.unitId, r.n);
+  return counts;
+}
+
+export type OrgAssignment = {
+  org_unit_id: string | null;
+  org_role_id: string | null;
+  division?: string;
+  position?: string;
+};
+
+/**
+ * Shared by the assignment endpoints and the legacy member write endpoints.
+ *
+ * Org ids are authoritative when present: the caller's `division`/`position`
+ * strings are overwritten with the unit/role names so the denormalized text
+ * columns cannot drift from the rows they mirror.
+ */
+export async function resolveOrgAssignment(
+  db: Db,
+  opts: {
+    ownerType: 'lembaga' | 'event';
+    ownerId: string;
+    org_unit_id?: string | null;
+    org_role_id?: string | null;
+  },
+): Promise<OrgAssignment> {
+  const { org_unit_id = null, org_role_id = null } = opts;
+  if (!org_unit_id && !org_role_id) {
+    return { org_unit_id: null, org_role_id: null };
+  }
+
+  const ownerMatches = (s: {
+    lembagaId: string | null;
+    eventId: string | null;
+  }) =>
+    opts.ownerType === 'lembaga'
+      ? s.lembagaId === opts.ownerId
+      : s.eventId === opts.ownerId;
+
+  const result: OrgAssignment = { org_unit_id, org_role_id };
+  let unitStructureId: string | null = null;
+  let roleStructureId: string | null = null;
+
+  if (org_unit_id) {
+    const rows = await db
+      .select({
+        name: organizationUnit.name,
+        structureId: organizationStructure.id,
+        lembagaId: organizationStructure.lembagaId,
+        eventId: organizationStructure.eventId,
+        is_active: organizationStructure.is_active,
+      })
+      .from(organizationUnit)
+      .innerJoin(
+        organizationStructure,
+        eq(organizationUnit.structure_id, organizationStructure.id),
+      )
+      .where(eq(organizationUnit.id, org_unit_id))
+      .limit(1);
+
+    const unit = rows[0];
+    if (!unit) {
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: 'Unit tidak ditemukan.',
+      });
+    }
+    if (!ownerMatches(unit)) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'Unit tersebut bukan milik lembaga/kegiatan ini.',
+      });
+    }
+    if (!unit.is_active) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'Struktur organisasi unit tersebut sudah tidak aktif.',
+      });
+    }
+    unitStructureId = unit.structureId;
+    result.division = unit.name;
+  }
+
+  if (org_role_id) {
+    const rows = await db
+      .select({
+        name: organizationRole.name,
+        structureId: organizationStructure.id,
+        lembagaId: organizationStructure.lembagaId,
+        eventId: organizationStructure.eventId,
+        is_active: organizationStructure.is_active,
+      })
+      .from(organizationRole)
+      .innerJoin(
+        organizationStructure,
+        eq(organizationRole.structure_id, organizationStructure.id),
+      )
+      .where(eq(organizationRole.id, org_role_id))
+      .limit(1);
+
+    const role = rows[0];
+    if (!role) {
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: 'Posisi tidak ditemukan.',
+      });
+    }
+    if (!ownerMatches(role)) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'Posisi tersebut bukan milik lembaga/kegiatan ini.',
+      });
+    }
+    if (!role.is_active) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'Struktur organisasi posisi tersebut sudah tidak aktif.',
+      });
+    }
+    roleStructureId = role.structureId;
+    result.position = role.name;
+  }
+
+  if (
+    unitStructureId &&
+    roleStructureId &&
+    unitStructureId !== roleStructureId
+  ) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Unit dan posisi harus berasal dari struktur yang sama.',
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Sibling reorder guard shared by unit and role: the submitted id set must match
+ * the stored set exactly, so a partial list can never silently renumber.
+ */
+export async function assertExactSiblingSet(
+  db: Db,
+  table: 'unit' | 'role',
+  structureId: string,
+  parentId: string | null,
+  submitted: string[],
+) {
+  const stored =
+    table === 'unit'
+      ? await db
+          .select({ id: organizationUnit.id })
+          .from(organizationUnit)
+          .where(
+            and(
+              eq(organizationUnit.structure_id, structureId),
+              parentId === null
+                ? isNull(organizationUnit.parent_id)
+                : eq(organizationUnit.parent_id, parentId),
+            ),
+          )
+      : await db
+          .select({ id: organizationRole.id })
+          .from(organizationRole)
+          .where(eq(organizationRole.structure_id, structureId));
+
+  const storedIds = new Set(stored.map((r) => r.id));
+  const submittedIds = new Set(submitted);
+
+  if (
+    submittedIds.size !== submitted.length ||
+    storedIds.size !== submittedIds.size ||
+    [...submittedIds].some((id) => !storedIds.has(id))
+  ) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message:
+        'Daftar urutan harus memuat tepat semua item pada tingkat yang sama, tanpa duplikat.',
+    });
+  }
+}
+
+/** Guard used before deleting a unit or role that members still point at. */
+export async function countMembersReferencing(
+  db: Db,
+  structure: StructureOwner,
+  column: 'org_unit_id' | 'org_role_id',
+  targetId: string,
+): Promise<number> {
+  const rows = structure.lembagaId
+    ? await db
+        .select({ n: sql<number>`count(*)::int` })
+        .from(kehimpunan)
+        .where(
+          and(
+            eq(kehimpunan.lembagaId, structure.lembagaId),
+            eq(
+              column === 'org_unit_id'
+                ? kehimpunan.org_unit_id
+                : kehimpunan.org_role_id,
+              targetId,
+            ),
+          ),
+        )
+    : await db
+        .select({ n: sql<number>`count(*)::int` })
+        .from(keanggotaan)
+        .where(
+          and(
+            eq(keanggotaan.event_id, structure.eventId!),
+            eq(
+              column === 'org_unit_id'
+                ? keanggotaan.org_unit_id
+                : keanggotaan.org_role_id,
+              targetId,
+            ),
+          ),
+        );
+
+  return rows[0]?.n ?? 0;
+}

--- a/src/server/api/routers/organization/structure.ts
+++ b/src/server/api/routers/organization/structure.ts
@@ -1,7 +1,212 @@
-import { createTRPCRouter } from '~/server/api/trpc';
+import { TRPCError } from '@trpc/server';
+import { and, desc, eq, isNull } from 'drizzle-orm';
+import { createTRPCRouter, lembagaProcedure } from '~/server/api/trpc';
+import {
+  CreateOrganizationStructureInputSchema,
+  CreateOrganizationStructureOutputSchema,
+  DeleteOrganizationStructureInputSchema,
+  DeleteOrganizationStructureOutputSchema,
+  GetAllOrganizationStructureInputSchema,
+  GetAllOrganizationStructureOutputSchema,
+  GetOrganizationStructureTreeInputSchema,
+  GetOrganizationStructureTreeOutputSchema,
+  UpdateOrganizationStructureInputSchema,
+  UpdateOrganizationStructureOutputSchema,
+} from '~/server/api/types/organization.type';
+import {
+  organizationRole,
+  organizationStructure,
+  organizationUnit,
+} from '~/server/db/schema';
 
-/**
- * SO-03 Fase 3 — CRUD struktur organisasi.
- * create / getAll / getTree / update / delete
- */
-export const organizationStructureRouter = createTRPCRouter({});
+import {
+  type StructureOwner,
+  buildUnitTree,
+  countMembersByUnit,
+  isUniqueViolation,
+  resolveOwnerScope,
+  resolveStructureOwnership,
+} from './services';
+
+const AKTIF_GANDA =
+  'Sudah ada struktur organisasi aktif. Nonaktifkan yang lama terlebih dahulu.';
+
+/** Drizzle row -> output contract (snake_case ids, as the API exposes them). */
+function toOutput(row: StructureOwner) {
+  return {
+    id: row.id,
+    lembaga_id: row.lembagaId,
+    event_id: row.eventId,
+    name: row.name,
+    is_active: row.is_active,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+export const organizationStructureRouter = createTRPCRouter({
+  create: lembagaProcedure
+    .input(CreateOrganizationStructureInputSchema)
+    .output(CreateOrganizationStructureOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const owner = await resolveOwnerScope(ctx, input.event_id);
+
+      try {
+        const rows = await ctx.db
+          .insert(organizationStructure)
+          .values({
+            lembagaId: owner.lembagaId,
+            eventId: owner.eventId,
+            name: input.name,
+            is_active: true,
+          })
+          .returning({ id: organizationStructure.id });
+
+        return { success: true, structure_id: rows[0]!.id };
+      } catch (error) {
+        if (error instanceof TRPCError) throw error;
+        // organization_structure_active_{lembaga,event}_unique
+        if (isUniqueViolation(error)) {
+          throw new TRPCError({ code: 'CONFLICT', message: AKTIF_GANDA });
+        }
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Gagal membuat struktur organisasi.',
+        });
+      }
+    }),
+
+  getAll: lembagaProcedure
+    .input(GetAllOrganizationStructureInputSchema)
+    .output(GetAllOrganizationStructureOutputSchema)
+    .query(async ({ ctx, input }) => {
+      const owner = await resolveOwnerScope(ctx, input.event_id);
+
+      const rows = await ctx.db
+        .select()
+        .from(organizationStructure)
+        .where(
+          owner.eventId
+            ? eq(organizationStructure.eventId, owner.eventId)
+            : and(
+                eq(organizationStructure.lembagaId, owner.lembagaId!),
+                isNull(organizationStructure.eventId),
+              ),
+        )
+        .orderBy(
+          desc(organizationStructure.is_active),
+          desc(organizationStructure.created_at),
+          organizationStructure.name,
+        );
+
+      return { structures: rows.map(toOutput) };
+    }),
+
+  getTree: lembagaProcedure
+    .input(GetOrganizationStructureTreeInputSchema)
+    .output(GetOrganizationStructureTreeOutputSchema)
+    .query(async ({ ctx, input }) => {
+      const structure = await resolveStructureOwnership(
+        ctx,
+        input.structure_id,
+      );
+
+      // Flat query + assemble in JS: depth is capped at 3, and this leaves an
+      // obvious place to attach member counts that a nested query would not.
+      const units = await ctx.db
+        .select({
+          id: organizationUnit.id,
+          structure_id: organizationUnit.structure_id,
+          parent_id: organizationUnit.parent_id,
+          name: organizationUnit.name,
+          kind: organizationUnit.kind,
+          level: organizationUnit.level,
+          sort_order: organizationUnit.sort_order,
+        })
+        .from(organizationUnit)
+        .where(eq(organizationUnit.structure_id, structure.id))
+        .orderBy(
+          organizationUnit.level,
+          organizationUnit.sort_order,
+          organizationUnit.name,
+        );
+
+      const roles = await ctx.db
+        .select({
+          id: organizationRole.id,
+          structure_id: organizationRole.structure_id,
+          name: organizationRole.name,
+          ring_level: organizationRole.ring_level,
+          sort_order: organizationRole.sort_order,
+        })
+        .from(organizationRole)
+        .where(eq(organizationRole.structure_id, structure.id))
+        .orderBy(
+          organizationRole.ring_level,
+          organizationRole.sort_order,
+          organizationRole.name,
+        );
+
+      const memberCounts = await countMembersByUnit(ctx.db, structure);
+
+      return {
+        structure: toOutput(structure),
+        units: buildUnitTree(units, memberCounts),
+        roles,
+      };
+    }),
+
+  update: lembagaProcedure
+    .input(UpdateOrganizationStructureInputSchema)
+    .output(UpdateOrganizationStructureOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      await resolveStructureOwnership(ctx, input.structure_id);
+
+      if (input.name === undefined && input.is_active === undefined) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Tidak ada perubahan yang dikirim.',
+        });
+      }
+
+      try {
+        await ctx.db
+          .update(organizationStructure)
+          .set({
+            ...(input.name !== undefined && { name: input.name }),
+            ...(input.is_active !== undefined && {
+              is_active: input.is_active,
+            }),
+          })
+          .where(eq(organizationStructure.id, input.structure_id));
+
+        return { success: true };
+      } catch (error) {
+        if (error instanceof TRPCError) throw error;
+        // Reactivating collides with the partial unique index just like create.
+        if (isUniqueViolation(error)) {
+          throw new TRPCError({ code: 'CONFLICT', message: AKTIF_GANDA });
+        }
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Gagal memperbarui struktur organisasi.',
+        });
+      }
+    }),
+
+  delete: lembagaProcedure
+    .input(DeleteOrganizationStructureInputSchema)
+    .output(DeleteOrganizationStructureOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      await resolveStructureOwnership(ctx, input.structure_id);
+
+      // Units and roles cascade. Member rows survive: their org_unit_id /
+      // org_role_id are set to NULL, and the legacy division/position text
+      // stays intact so every existing read path keeps working.
+      await ctx.db
+        .delete(organizationStructure)
+        .where(eq(organizationStructure.id, input.structure_id));
+
+      return { success: true };
+    }),
+});

--- a/src/server/api/routers/organization/structure.ts
+++ b/src/server/api/routers/organization/structure.ts
@@ -1,0 +1,7 @@
+import { createTRPCRouter } from '~/server/api/trpc';
+
+/**
+ * SO-03 Fase 3 — CRUD struktur organisasi.
+ * create / getAll / getTree / update / delete
+ */
+export const organizationStructureRouter = createTRPCRouter({});

--- a/src/server/api/routers/organization/unit.ts
+++ b/src/server/api/routers/organization/unit.ts
@@ -1,7 +1,406 @@
-import { createTRPCRouter } from '~/server/api/trpc';
+import { TRPCError } from '@trpc/server';
+import { and, eq, isNull, max } from 'drizzle-orm';
+import { createTRPCRouter, lembagaProcedure } from '~/server/api/trpc';
+import {
+  CreateOrganizationUnitInputSchema,
+  CreateOrganizationUnitOutputSchema,
+  DeleteOrganizationUnitInputSchema,
+  DeleteOrganizationUnitOutputSchema,
+  GetAllOrganizationUnitInputSchema,
+  GetAllOrganizationUnitOutputSchema,
+  MoveOrganizationUnitInputSchema,
+  MoveOrganizationUnitOutputSchema,
+  ReorderOrganizationUnitInputSchema,
+  ReorderOrganizationUnitOutputSchema,
+  UpdateOrganizationUnitInputSchema,
+  UpdateOrganizationUnitOutputSchema,
+} from '~/server/api/types/organization.type';
+import { keanggotaan, kehimpunan, organizationUnit } from '~/server/db/schema';
 
-/**
- * SO-03 Fase 4 — CRUD unit (Bidang/Divisi/Subdivisi).
- * create / update / move / reorder / delete / getAll
- */
-export const organizationUnitRouter = createTRPCRouter({});
+import {
+  type FlatUnit,
+  ORGANIZATION_UNIT_MAX_LEVEL,
+  type StructureOwner,
+  buildPathLabels,
+  countMembersReferencing,
+  isForeignKeyViolation,
+  resolveParentPlacement,
+  resolveStructureOwnership,
+  resolveUnitOwnership,
+} from './services';
+
+const UNIT_COLUMNS = {
+  id: organizationUnit.id,
+  structure_id: organizationUnit.structure_id,
+  parent_id: organizationUnit.parent_id,
+  name: organizationUnit.name,
+  kind: organizationUnit.kind,
+  level: organizationUnit.level,
+  sort_order: organizationUnit.sort_order,
+};
+
+type Db = Parameters<typeof countMembersReferencing>[0];
+
+function loadStructureUnits(db: Db, structureId: string) {
+  return db
+    .select(UNIT_COLUMNS)
+    .from(organizationUnit)
+    .where(eq(organizationUnit.structure_id, structureId))
+    .orderBy(
+      organizationUnit.level,
+      organizationUnit.sort_order,
+      organizationUnit.name,
+    );
+}
+
+/** Every unit below `rootId`, walked breadth-first over the flat list. */
+function collectDescendants(units: FlatUnit[], rootId: string): FlatUnit[] {
+  const childrenOf = new Map<string, FlatUnit[]>();
+  for (const u of units) {
+    if (!u.parent_id) continue;
+    const list = childrenOf.get(u.parent_id);
+    if (list) list.push(u);
+    else childrenOf.set(u.parent_id, [u]);
+  }
+
+  const out: FlatUnit[] = [];
+  const stack = [rootId];
+  while (stack.length > 0) {
+    const id = stack.pop()!;
+    for (const child of childrenOf.get(id) ?? []) {
+      out.push(child);
+      stack.push(child.id);
+    }
+  }
+  return out;
+}
+
+/** Next sort_order among the target siblings, so new units land at the end. */
+async function nextSortOrder(
+  db: Db,
+  structureId: string,
+  parentId: string | null,
+): Promise<number> {
+  const rows = await db
+    .select({ value: max(organizationUnit.sort_order) })
+    .from(organizationUnit)
+    .where(
+      and(
+        eq(organizationUnit.structure_id, structureId),
+        parentId === null
+          ? isNull(organizationUnit.parent_id)
+          : eq(organizationUnit.parent_id, parentId),
+      ),
+    );
+  return (rows[0]?.value ?? -1) + 1;
+}
+
+/** Keeps the denormalized `division` text on member rows in step with a rename. */
+async function propagateUnitName(
+  tx: Db,
+  structure: StructureOwner,
+  unitId: string,
+  name: string,
+) {
+  if (structure.lembagaId) {
+    await tx
+      .update(kehimpunan)
+      .set({ division: name })
+      .where(
+        and(
+          eq(kehimpunan.lembagaId, structure.lembagaId),
+          eq(kehimpunan.org_unit_id, unitId),
+        ),
+      );
+    return;
+  }
+  if (structure.eventId) {
+    await tx
+      .update(keanggotaan)
+      .set({ division: name })
+      .where(
+        and(
+          eq(keanggotaan.event_id, structure.eventId),
+          eq(keanggotaan.org_unit_id, unitId),
+        ),
+      );
+  }
+}
+
+export const organizationUnitRouter = createTRPCRouter({
+  create: lembagaProcedure
+    .input(CreateOrganizationUnitInputSchema)
+    .output(CreateOrganizationUnitOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      await resolveStructureOwnership(ctx, input.structure_id);
+
+      let parent: FlatUnit | null = null;
+      if (input.parent_id) {
+        const rows = await ctx.db
+          .select(UNIT_COLUMNS)
+          .from(organizationUnit)
+          .where(
+            and(
+              eq(organizationUnit.id, input.parent_id),
+              eq(organizationUnit.structure_id, input.structure_id),
+            ),
+          )
+          .limit(1);
+        parent = rows[0] ?? null;
+        if (!parent) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Induk tidak ditemukan di struktur organisasi ini.',
+          });
+        }
+      }
+
+      // `level` is derived, never accepted from input — that kills an entire
+      // class of kind/level inconsistency at the source.
+      const level = resolveParentPlacement(
+        input.kind,
+        parent,
+        input.structure_id,
+      );
+
+      const unitId = await ctx.db.transaction(async (tx) => {
+        const sortOrder = await nextSortOrder(
+          tx,
+          input.structure_id,
+          input.parent_id ?? null,
+        );
+        const rows = await tx
+          .insert(organizationUnit)
+          .values({
+            structure_id: input.structure_id,
+            parent_id: input.parent_id ?? null,
+            name: input.name,
+            kind: input.kind,
+            level,
+            sort_order: sortOrder,
+          })
+          .returning({ id: organizationUnit.id });
+        return rows[0]!.id;
+      });
+
+      return { success: true, unit_id: unitId };
+    }),
+
+  update: lembagaProcedure
+    .input(UpdateOrganizationUnitInputSchema)
+    .output(UpdateOrganizationUnitOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { structure } = await resolveUnitOwnership(ctx, input.unit_id);
+
+      await ctx.db.transaction(async (tx) => {
+        await tx
+          .update(organizationUnit)
+          .set({ name: input.name })
+          .where(eq(organizationUnit.id, input.unit_id));
+
+        // UPDATE only — the member_count triggers fire on INSERT/DELETE, so
+        // counts stay untouched.
+        await propagateUnitName(tx, structure, input.unit_id, input.name);
+      });
+
+      return { success: true };
+    }),
+
+  move: lembagaProcedure
+    .input(MoveOrganizationUnitInputSchema)
+    .output(MoveOrganizationUnitOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { unit, structure } = await resolveUnitOwnership(
+        ctx,
+        input.unit_id,
+      );
+
+      if (input.parent_id === input.unit_id) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Unit tidak dapat menjadi induk dirinya sendiri.',
+        });
+      }
+
+      const units = await loadStructureUnits(ctx.db, structure.id);
+      const descendants = collectDescendants(units, unit.id);
+
+      let parent: FlatUnit | null = null;
+      if (input.parent_id) {
+        parent = units.find((u) => u.id === input.parent_id) ?? null;
+        if (!parent) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Induk tidak ditemukan di struktur organisasi ini.',
+          });
+        }
+        // The kind ordering already makes cycles structurally impossible, but
+        // check explicitly so a future rule change cannot open the hole.
+        if (descendants.some((d) => d.id === parent!.id)) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message:
+              'Unit tidak dapat dipindahkan ke dalam turunannya sendiri.',
+          });
+        }
+      }
+
+      const newLevel = resolveParentPlacement(unit.kind, parent, structure.id);
+      const delta = newLevel - unit.level;
+
+      // Moving a unit drags its whole subtree along; the deepest descendant is
+      // what decides whether the move still fits inside the 3-level cap.
+      const deepest = descendants.reduce(
+        (m, d) => Math.max(m, d.level),
+        unit.level,
+      );
+      if (deepest + delta > ORGANIZATION_UNIT_MAX_LEVEL) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `Pemindahan membuat struktur melebihi ${ORGANIZATION_UNIT_MAX_LEVEL} tingkat.`,
+        });
+      }
+
+      if (delta === 0 && unit.parent_id === (input.parent_id ?? null)) {
+        return { success: true };
+      }
+
+      await ctx.db.transaction(async (tx) => {
+        const sortOrder = await nextSortOrder(
+          tx,
+          structure.id,
+          input.parent_id ?? null,
+        );
+        await tx
+          .update(organizationUnit)
+          .set({
+            parent_id: input.parent_id ?? null,
+            level: newLevel,
+            sort_order: sortOrder,
+          })
+          .where(eq(organizationUnit.id, unit.id));
+
+        // Descendants keep their shape but shift with the subtree, otherwise
+        // `level` silently desyncs from real depth — the DB CHECK only guards
+        // the root case and would not catch it.
+        if (delta !== 0) {
+          for (const d of descendants) {
+            await tx
+              .update(organizationUnit)
+              .set({ level: d.level + delta })
+              .where(eq(organizationUnit.id, d.id));
+          }
+        }
+      });
+
+      return { success: true };
+    }),
+
+  reorder: lembagaProcedure
+    .input(ReorderOrganizationUnitInputSchema)
+    .output(ReorderOrganizationUnitOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      await resolveStructureOwnership(ctx, input.structure_id);
+
+      const units = await loadStructureUnits(ctx.db, input.structure_id);
+      const siblings = units.filter(
+        (u) => (u.parent_id ?? null) === input.parent_id,
+      );
+
+      const storedIds = new Set(siblings.map((s) => s.id));
+      const submitted = new Set(input.unit_ids);
+      if (
+        submitted.size !== input.unit_ids.length ||
+        storedIds.size !== submitted.size ||
+        input.unit_ids.some((id) => !storedIds.has(id))
+      ) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message:
+            'Daftar urutan harus memuat tepat semua unit pada tingkat yang sama, tanpa duplikat.',
+        });
+      }
+
+      await ctx.db.transaction(async (tx) => {
+        for (const [i, id] of input.unit_ids.entries()) {
+          await tx
+            .update(organizationUnit)
+            .set({ sort_order: i })
+            .where(eq(organizationUnit.id, id));
+        }
+      });
+
+      return { success: true };
+    }),
+
+  delete: lembagaProcedure
+    .input(DeleteOrganizationUnitInputSchema)
+    .output(DeleteOrganizationUnitOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { structure } = await resolveUnitOwnership(ctx, input.unit_id);
+
+      const children = await ctx.db
+        .select({ id: organizationUnit.id })
+        .from(organizationUnit)
+        .where(eq(organizationUnit.parent_id, input.unit_id))
+        .limit(1);
+      if (children.length > 0) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message:
+            'Unit masih memiliki sub-unit. Hapus atau pindahkan sub-unit terlebih dahulu.',
+        });
+      }
+
+      const members = await countMembersReferencing(
+        ctx.db,
+        structure,
+        'org_unit_id',
+        input.unit_id,
+      );
+      if (members > 0) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: `Masih ada ${members} anggota yang ditugaskan pada unit ini.`,
+        });
+      }
+
+      try {
+        await ctx.db
+          .delete(organizationUnit)
+          .where(eq(organizationUnit.id, input.unit_id));
+      } catch (error) {
+        if (error instanceof TRPCError) throw error;
+        // Backstop for a child inserted between the pre-check and the delete.
+        if (isForeignKeyViolation(error)) {
+          throw new TRPCError({
+            code: 'CONFLICT',
+            message: 'Unit masih direferensikan oleh data lain.',
+          });
+        }
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Gagal menghapus unit.',
+        });
+      }
+
+      return { success: true };
+    }),
+
+  getAll: lembagaProcedure
+    .input(GetAllOrganizationUnitInputSchema)
+    .output(GetAllOrganizationUnitOutputSchema)
+    .query(async ({ ctx, input }) => {
+      await resolveStructureOwnership(ctx, input.structure_id);
+
+      const units = await loadStructureUnits(ctx.db, input.structure_id);
+      const labels = buildPathLabels(units);
+
+      return {
+        units: units.map((u) => ({
+          ...u,
+          path_label: labels.get(u.id) ?? u.name,
+        })),
+      };
+    }),
+});

--- a/src/server/api/routers/organization/unit.ts
+++ b/src/server/api/routers/organization/unit.ts
@@ -1,0 +1,7 @@
+import { createTRPCRouter } from '~/server/api/trpc';
+
+/**
+ * SO-03 Fase 4 — CRUD unit (Bidang/Divisi/Subdivisi).
+ * create / update / move / reorder / delete / getAll
+ */
+export const organizationUnitRouter = createTRPCRouter({});

--- a/src/server/api/types/event.type.ts
+++ b/src/server/api/types/event.type.ts
@@ -49,6 +49,8 @@ export const AddNewPanitiaKegiatanInputSchema = z.object({
   user_id: z.string(),
   position: z.string(),
   division: z.string(),
+  org_unit_id: z.string().nonempty().optional(),
+  org_role_id: z.string().nonempty().optional(),
 });
 
 export const AddNewPanitiaKegiatanOutputSchema = z.object({
@@ -92,6 +94,8 @@ export const AddNewPanitiaKegiatanManualInputSchema = z.object({
   nim: z.string().regex(/^\d{8}$/, 'NIM harus 8 digit angka'),
   position: z.string().nonempty(),
   division: z.string().nonempty(),
+  org_unit_id: z.string().nonempty().optional(),
+  org_role_id: z.string().nonempty().optional(),
 });
 
 export const EventIdSchema = z.object({

--- a/src/server/api/types/lembaga.type.ts
+++ b/src/server/api/types/lembaga.type.ts
@@ -82,6 +82,8 @@ export const AddAnggotaLembagaInputSchema = z.object({
   user_id: z.string().nonempty(),
   division: z.string().nonempty(),
   position: z.string().nonempty(),
+  org_unit_id: z.string().nonempty().optional(),
+  org_role_id: z.string().nonempty().optional(),
 });
 
 export const AddAnggotaManualLembagaInputSchema = z.object({
@@ -89,6 +91,8 @@ export const AddAnggotaManualLembagaInputSchema = z.object({
   nim: z.string().regex(/^\d{8}$/, 'NIM harus 8 digit angka'),
   division: z.string().nonempty(),
   position: z.string().nonempty(),
+  org_unit_id: z.string().nonempty().optional(),
+  org_role_id: z.string().nonempty().optional(),
 });
 
 export const AddAnggotaLembagaOutputSchema = z.object({
@@ -108,6 +112,8 @@ export const editAnggotaLembagaInputSchema = z.object({
   user_id: z.string().nonempty(),
   division: z.string().nonempty(),
   position: z.string().nonempty(),
+  org_unit_id: z.string().nonempty().optional(),
+  org_role_id: z.string().nonempty().optional(),
 });
 
 export const editAnggotaLembagaOutputSchema = z.object({

--- a/src/server/api/types/organization.type.ts
+++ b/src/server/api/types/organization.type.ts
@@ -1,0 +1,276 @@
+import { z } from 'zod';
+import { ORGANIZATION_UNIT_KINDS } from '~/server/db/schema';
+
+const OrganizationUnitKindSchema = z.enum(ORGANIZATION_UNIT_KINDS, {
+  errorMap: () => ({ message: 'Jenis unit tidak valid' }),
+});
+
+const OrganizationStructureSchema = z.object({
+  id: z.string(),
+  lembaga_id: z.string().nullable(),
+  event_id: z.string().nullable(),
+  name: z.string(),
+  is_active: z.boolean(),
+  created_at: z.date(),
+  updated_at: z.date(),
+});
+
+const OrganizationUnitBaseSchema = z.object({
+  id: z.string(),
+  structure_id: z.string(),
+  parent_id: z.string().nullable(),
+  name: z.string(),
+  kind: OrganizationUnitKindSchema,
+  level: z.number().int(),
+  sort_order: z.number().int(),
+});
+
+/**
+ * Tree depth is capped at 3 by `organization_unit_level_range_check`, so the
+ * nesting is spelled out level by level instead of using `z.lazy`. A recursive
+ * zod type needs an explicit `z.ZodType<T>` annotation that kills inference,
+ * and it would happily validate a 4-level tree. These three encode the
+ * max-depth invariant in the contract itself.
+ */
+const OrganizationUnitLevel3Schema = OrganizationUnitBaseSchema.extend({
+  member_count: z.number().int(),
+  // buildUnitTree always emits `children`, so the key must be allowed — but a
+  // non-empty one at depth 3 means the tree builder produced a 4th level.
+  // Rejecting is deliberate: zod would otherwise strip it and lose rows
+  // silently, hiding the bug instead of surfacing it.
+  children: z
+    .array(z.unknown())
+    .max(0, 'Struktur organisasi maksimal 3 tingkat')
+    .optional(),
+});
+
+const OrganizationUnitLevel2Schema = OrganizationUnitBaseSchema.extend({
+  member_count: z.number().int(),
+  children: z.array(OrganizationUnitLevel3Schema),
+});
+
+const OrganizationUnitLevel1Schema = OrganizationUnitBaseSchema.extend({
+  member_count: z.number().int(),
+  children: z.array(OrganizationUnitLevel2Schema),
+});
+
+/** Flat shape for dropdowns; `path_label` reads like "Bidang A / Divisi B". */
+const OrganizationUnitFlatSchema = OrganizationUnitBaseSchema.extend({
+  path_label: z.string(),
+});
+
+const OrganizationRoleSchema = z.object({
+  id: z.string(),
+  structure_id: z.string(),
+  name: z.string(),
+  ring_level: z.number().int(),
+  sort_order: z.number().int(),
+});
+
+const MutationSuccessSchema = z.object({ success: z.boolean() });
+
+const structureId = z.string().nonempty('Struktur organisasi wajib dipilih');
+const unitId = z.string().nonempty('Unit wajib dipilih');
+const roleId = z.string().nonempty('Posisi wajib dipilih');
+const namaUnit = z
+  .string()
+  .min(1, 'Nama wajib diisi')
+  .max(255, 'Nama maksimal 255 karakter');
+
+// --- structure ---------------------------------------------------------------
+
+export const CreateOrganizationStructureInputSchema = z.object({
+  name: namaUnit,
+  // Absent means the structure belongs to the caller's own lembaga. The owner
+  // is never taken from input beyond this.
+  event_id: z.string().nonempty().optional(),
+});
+
+export const CreateOrganizationStructureOutputSchema = z.object({
+  success: z.boolean(),
+  structure_id: z.string(),
+});
+
+export const GetAllOrganizationStructureInputSchema = z.object({
+  event_id: z.string().nonempty().optional(),
+});
+
+export const GetAllOrganizationStructureOutputSchema = z.object({
+  structures: z.array(OrganizationStructureSchema),
+});
+
+export const GetOrganizationStructureTreeInputSchema = z.object({
+  structure_id: structureId,
+});
+
+export const GetOrganizationStructureTreeOutputSchema = z.object({
+  structure: OrganizationStructureSchema,
+  units: z.array(OrganizationUnitLevel1Schema),
+  roles: z.array(OrganizationRoleSchema),
+});
+
+export const UpdateOrganizationStructureInputSchema = z.object({
+  structure_id: structureId,
+  name: namaUnit.optional(),
+  is_active: z.boolean().optional(),
+});
+
+export const UpdateOrganizationStructureOutputSchema = MutationSuccessSchema;
+
+export const DeleteOrganizationStructureInputSchema = z.object({
+  structure_id: structureId,
+});
+
+export const DeleteOrganizationStructureOutputSchema = MutationSuccessSchema;
+
+// --- unit --------------------------------------------------------------------
+
+export const CreateOrganizationUnitInputSchema = z.object({
+  structure_id: structureId,
+  name: namaUnit,
+  kind: OrganizationUnitKindSchema,
+  // `level` is intentionally absent: it is derived from the parent's depth.
+  parent_id: z.string().nonempty().optional(),
+});
+
+export const CreateOrganizationUnitOutputSchema = z.object({
+  success: z.boolean(),
+  unit_id: z.string(),
+});
+
+export const UpdateOrganizationUnitInputSchema = z.object({
+  unit_id: unitId,
+  name: namaUnit,
+});
+
+export const UpdateOrganizationUnitOutputSchema = MutationSuccessSchema;
+
+export const MoveOrganizationUnitInputSchema = z.object({
+  unit_id: unitId,
+  // null promotes the unit to a root.
+  parent_id: z.string().nonempty().nullable(),
+});
+
+export const MoveOrganizationUnitOutputSchema = MutationSuccessSchema;
+
+export const ReorderOrganizationUnitInputSchema = z.object({
+  structure_id: structureId,
+  parent_id: z.string().nonempty().nullable(),
+  unit_ids: z
+    .array(z.string().nonempty())
+    .min(1, 'Daftar unit tidak boleh kosong'),
+});
+
+export const ReorderOrganizationUnitOutputSchema = MutationSuccessSchema;
+
+export const DeleteOrganizationUnitInputSchema = z.object({ unit_id: unitId });
+
+export const DeleteOrganizationUnitOutputSchema = MutationSuccessSchema;
+
+export const GetAllOrganizationUnitInputSchema = z.object({
+  structure_id: structureId,
+});
+
+export const GetAllOrganizationUnitOutputSchema = z.object({
+  units: z.array(OrganizationUnitFlatSchema),
+});
+
+// --- role --------------------------------------------------------------------
+
+export const CreateOrganizationRoleInputSchema = z.object({
+  structure_id: structureId,
+  name: namaUnit,
+  ring_level: z
+    .number()
+    .int('Ring level harus bilangan bulat')
+    .min(1, 'Ring level minimal 1'),
+});
+
+export const CreateOrganizationRoleOutputSchema = z.object({
+  success: z.boolean(),
+  role_id: z.string(),
+});
+
+export const UpdateOrganizationRoleInputSchema = z.object({
+  role_id: roleId,
+  name: namaUnit.optional(),
+  ring_level: z
+    .number()
+    .int('Ring level harus bilangan bulat')
+    .min(1, 'Ring level minimal 1')
+    .optional(),
+});
+
+export const UpdateOrganizationRoleOutputSchema = MutationSuccessSchema;
+
+export const ReorderOrganizationRoleInputSchema = z.object({
+  structure_id: structureId,
+  role_ids: z
+    .array(z.string().nonempty())
+    .min(1, 'Daftar posisi tidak boleh kosong'),
+});
+
+export const ReorderOrganizationRoleOutputSchema = MutationSuccessSchema;
+
+export const DeleteOrganizationRoleInputSchema = z.object({ role_id: roleId });
+
+export const DeleteOrganizationRoleOutputSchema = MutationSuccessSchema;
+
+export const GetAllOrganizationRoleInputSchema = z.object({
+  structure_id: structureId,
+});
+
+export const GetAllOrganizationRoleOutputSchema = z.object({
+  roles: z.array(OrganizationRoleSchema),
+});
+
+// --- assignment --------------------------------------------------------------
+
+const minimalSatuTarget = {
+  message: 'Pilih minimal unit atau posisi',
+  path: ['org_unit_id'] as const,
+};
+
+export const AssignAnggotaLembagaOrganizationInputSchema = z
+  .object({
+    user_id: z.string().nonempty(),
+    org_unit_id: z.string().nonempty().optional(),
+    org_role_id: z.string().nonempty().optional(),
+  })
+  .refine((v) => v.org_unit_id != null || v.org_role_id != null, {
+    message: minimalSatuTarget.message,
+    path: [...minimalSatuTarget.path],
+  });
+
+export const AssignAnggotaLembagaOrganizationOutputSchema =
+  MutationSuccessSchema;
+
+export const UnassignAnggotaLembagaOrganizationInputSchema = z.object({
+  user_id: z.string().nonempty(),
+});
+
+export const UnassignAnggotaLembagaOrganizationOutputSchema =
+  MutationSuccessSchema;
+
+export const AssignPanitiaKegiatanOrganizationInputSchema = z
+  .object({
+    event_id: z.string().nonempty(),
+    user_id: z.string().nonempty(),
+    org_unit_id: z.string().nonempty().optional(),
+    org_role_id: z.string().nonempty().optional(),
+  })
+  .refine((v) => v.org_unit_id != null || v.org_role_id != null, {
+    message: minimalSatuTarget.message,
+    path: [...minimalSatuTarget.path],
+  });
+
+export const AssignPanitiaKegiatanOrganizationOutputSchema =
+  MutationSuccessSchema;
+
+export const UnassignPanitiaKegiatanOrganizationInputSchema = z.object({
+  event_id: z.string().nonempty(),
+  user_id: z.string().nonempty(),
+});
+
+export const UnassignPanitiaKegiatanOrganizationOutputSchema =
+  MutationSuccessSchema;

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -272,8 +272,14 @@ export const keanggotaan = createTable(
     user_id: varchar('user_id', { length: 255 })
       .references(() => users.id)
       .notNull(),
-    org_unit_id: varchar('org_unit_id', { length: 255 }),
-    org_role_id: varchar('org_role_id', { length: 255 }),
+    org_unit_id: varchar('org_unit_id', { length: 255 }).references(
+      () => organizationUnit.id,
+      { onDelete: 'set null' },
+    ),
+    org_role_id: varchar('org_role_id', { length: 255 }).references(
+      () => organizationRole.id,
+      { onDelete: 'set null' },
+    ),
     position: varchar('position', { length: 255 }).notNull(),
     division: varchar('division', { length: 255 }).notNull(),
     index: integer('index').notNull().default(0),
@@ -284,6 +290,10 @@ export const keanggotaan = createTable(
       table.event_id,
       table.user_id,
     ),
+    // Postgres does not index the child side of a FK, and ON DELETE SET NULL
+    // scans it on every organization_unit/_role delete.
+    orgUnitIdx: index('keanggotaan_org_unit_idx').on(table.org_unit_id),
+    orgRoleIdx: index('keanggotaan_org_role_idx').on(table.org_role_id),
   }),
 );
 
@@ -296,8 +306,14 @@ export const associationRequests = createTable('association_request', {
   user_id: varchar('user_id', { length: 255 }).references(() => users.id, {
     onDelete: 'cascade',
   }),
-  org_unit_id: varchar('org_unit_id', { length: 255 }),
-  org_role_id: varchar('org_role_id', { length: 255 }),
+  org_unit_id: varchar('org_unit_id', { length: 255 }).references(
+    () => organizationUnit.id,
+    { onDelete: 'set null' },
+  ),
+  org_role_id: varchar('org_role_id', { length: 255 }).references(
+    () => organizationRole.id,
+    { onDelete: 'set null' },
+  ),
   position: varchar('position', { length: 255 }).notNull(),
   division: varchar('division', { length: 255 }).notNull(),
   status: associationRequestStatusEnum('status').notNull().default('Pending'),
@@ -313,8 +329,14 @@ export const associationRequestsLembaga = createTable(
       () => lembaga.id,
     ),
     user_id: varchar('user_id', { length: 255 }).references(() => users.id),
-    org_unit_id: varchar('org_unit_id', { length: 255 }),
-    org_role_id: varchar('org_role_id', { length: 255 }),
+    org_unit_id: varchar('org_unit_id', { length: 255 }).references(
+      () => organizationUnit.id,
+      { onDelete: 'set null' },
+    ),
+    org_role_id: varchar('org_role_id', { length: 255 }).references(
+      () => organizationRole.id,
+      { onDelete: 'set null' },
+    ),
     position: varchar('position', { length: 255 }).notNull(),
     division: varchar('division', { length: 255 }).notNull(),
     status: associationRequestStatusEnum('status').notNull().default('Pending'),
@@ -472,8 +494,14 @@ export const kehimpunan = createTable(
     lembagaId: varchar('lembaga_id', { length: 255 })
       .notNull()
       .references(() => lembaga.id),
-    org_unit_id: varchar('org_unit_id', { length: 255 }),
-    org_role_id: varchar('org_role_id', { length: 255 }),
+    org_unit_id: varchar('org_unit_id', { length: 255 }).references(
+      () => organizationUnit.id,
+      { onDelete: 'set null' },
+    ),
+    org_role_id: varchar('org_role_id', { length: 255 }).references(
+      () => organizationRole.id,
+      { onDelete: 'set null' },
+    ),
     division: varchar('division', { length: 255 }).notNull(),
     position: varchar('position', { length: 255 }).notNull(),
     index: integer('index').notNull().default(0),
@@ -483,6 +511,10 @@ export const kehimpunan = createTable(
       table.lembagaId,
       table.userId,
     ),
+    // Postgres does not index the child side of a FK, and ON DELETE SET NULL
+    // scans it on every organization_unit/_role delete.
+    orgUnitIdx: index('kehimpunan_org_unit_idx').on(table.org_unit_id),
+    orgRoleIdx: index('kehimpunan_org_role_idx').on(table.org_role_id),
   }),
 );
 
@@ -498,57 +530,115 @@ export const kehimpunanRelations = relations(kehimpunan, ({ one }) => ({
 }));
 
 // Organization Structure
-export const organizationStructure = createTable('organization_structure', {
-  id: varchar('id', { length: 255 })
-    .notNull()
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  lembagaId: varchar('lembaga_id', { length: 255 }).references(
-    () => lembaga.id,
-    { onDelete: 'cascade' },
-  ),
-  eventId: varchar('event_id', { length: 255 }).references(() => events.id, {
-    onDelete: 'cascade',
+export const organizationStructure = createTable(
+  'organization_structure',
+  {
+    id: varchar('id', { length: 255 })
+      .notNull()
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    lembagaId: varchar('lembaga_id', { length: 255 }).references(
+      () => lembaga.id,
+      { onDelete: 'cascade' },
+    ),
+    eventId: varchar('event_id', { length: 255 }).references(() => events.id, {
+      onDelete: 'cascade',
+    }),
+    name: varchar('name', { length: 255 }).notNull(),
+    is_active: boolean('is_active').notNull().default(true),
+    ...timestamps,
+  },
+  (table) => ({
+    // A structure belongs to exactly one owner; the XOR itself is a CHECK
+    // constraint hand-written in the migration (drizzle-kit cannot emit those).
+    activeLembagaUnique: uniqueIndex(
+      'organization_structure_active_lembaga_unique',
+    )
+      .on(table.lembagaId)
+      .where(sql`${table.is_active} = true AND ${table.lembagaId} IS NOT NULL`),
+    activeEventUnique: uniqueIndex('organization_structure_active_event_unique')
+      .on(table.eventId)
+      .where(sql`${table.is_active} = true AND ${table.eventId} IS NOT NULL`),
   }),
-  name: varchar('name', { length: 255 }).notNull(),
-  is_active: boolean('is_active').notNull().default(true),
-  ...timestamps,
-});
+);
+
+/**
+ * Labels a unit carries. `level` is the unit's DEPTH in the tree (root = 1),
+ * NOT a fixed function of `kind` — existing production data is flat, with
+ * `Divisi` sitting at level 1 as a root. Ordering rules between kinds are
+ * enforced in the router, not the database.
+ */
+export const ORGANIZATION_UNIT_KINDS = [
+  'Bidang',
+  'Divisi',
+  'Subdivisi',
+] as const;
+export type OrganizationUnitKind = (typeof ORGANIZATION_UNIT_KINDS)[number];
+
+export const ORGANIZATION_UNIT_MAX_LEVEL = 3;
 
 // Organization Unit
-export const organizationUnit = createTable('organization_unit', {
-  id: varchar('id', { length: 255 })
-    .notNull()
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  structure_id: varchar('structure_id', { length: 255 })
-    .references(() => organizationStructure.id, { onDelete: 'cascade' })
-    .notNull(),
-  parent_id: varchar('parent_id', { length: 255 }).references(
-    () => organizationUnit.id,
-    { onDelete: 'restrict' },
-  ),
-  name: varchar('name', { length: 255 }).notNull(),
-  kind: varchar('kind', { length: 255 }).notNull(),
-  level: integer('level').notNull(),
-  sort_order: integer('sort_order').notNull().default(0),
-  ...timestamps,
-});
+export const organizationUnit = createTable(
+  'organization_unit',
+  {
+    id: varchar('id', { length: 255 })
+      .notNull()
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    structure_id: varchar('structure_id', { length: 255 })
+      .references(() => organizationStructure.id, { onDelete: 'cascade' })
+      .notNull(),
+    // `no action` rather than `restrict`: restrict is checked immediately, so
+    // cascading a structure delete into a multi-level tree would abort with
+    // 23503 and make deleting a lembaga fail. `no action` defers the check to
+    // end-of-statement, still rejecting a direct delete of a unit with children.
+    parent_id: varchar('parent_id', { length: 255 }).references(
+      () => organizationUnit.id,
+      { onDelete: 'no action' },
+    ),
+    name: varchar('name', { length: 255 }).notNull(),
+    kind: varchar('kind', { length: 255 })
+      .$type<OrganizationUnitKind>()
+      .notNull(),
+    level: integer('level').notNull(),
+    sort_order: integer('sort_order').notNull().default(0),
+    ...timestamps,
+  },
+  (table) => ({
+    structureIdx: index('organization_unit_structure_idx').on(
+      table.structure_id,
+    ),
+    parentIdx: index('organization_unit_parent_idx').on(table.parent_id),
+    siblingOrderIdx: index('organization_unit_sibling_order_idx').on(
+      table.structure_id,
+      table.parent_id,
+      table.sort_order,
+    ),
+  }),
+);
 
 // Organization Role
-export const organizationRole = createTable('organization_role', {
-  id: varchar('id', { length: 255 })
-    .notNull()
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  structure_id: varchar('structure_id', { length: 255 })
-    .references(() => organizationStructure.id, { onDelete: 'cascade' })
-    .notNull(),
-  name: varchar('name', { length: 255 }).notNull(),
-  ring_level: integer('ring_level').notNull(),
-  sort_order: integer('sort_order').notNull().default(0),
-  ...timestamps,
-});
+export const organizationRole = createTable(
+  'organization_role',
+  {
+    id: varchar('id', { length: 255 })
+      .notNull()
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    structure_id: varchar('structure_id', { length: 255 })
+      .references(() => organizationStructure.id, { onDelete: 'cascade' })
+      .notNull(),
+    name: varchar('name', { length: 255 }).notNull(),
+    ring_level: integer('ring_level').notNull(),
+    sort_order: integer('sort_order').notNull().default(0),
+    ...timestamps,
+  },
+  (table) => ({
+    structureIdx: index('organization_role_structure_idx').on(
+      table.structure_id,
+    ),
+  }),
+);
 
 // Best Staff
 export const bestStaffKegiatan = createTable('best_staff_kegiatan', {

--- a/src/server/db/seeding/clear-db.ts
+++ b/src/server/db/seeding/clear-db.ts
@@ -15,6 +15,9 @@ import {
   nilaiProfilKegiatan,
   nilaiProfilLembaga,
   notifications,
+  organizationRole,
+  organizationStructure,
+  organizationUnit,
   pemetaanProfilKegiatan,
   pemetaanProfilLembaga,
   profilKM,
@@ -65,6 +68,13 @@ async function clearAllTables() {
     await safeDelete(profilKM, 'profilKM');
     await safeDelete(bestStaffLembaga, 'bestStaffLembaga');
     await safeDelete(bestStaffKegiatan, 'bestStaffKegiatan');
+    // Organization tables before the membership tables: keanggotaan/kehimpunan
+    // point at them via ON DELETE SET NULL, and those rows are deleted below
+    // anyway. Units go first so the self-referencing parent_id is emptied in
+    // one statement rather than relying on the structure cascade.
+    await safeDelete(organizationUnit, 'organizationUnit');
+    await safeDelete(organizationRole, 'organizationRole');
+    await safeDelete(organizationStructure, 'organizationStructure');
     await safeDelete(kehimpunan, 'kehimpunan');
     await safeDelete(notifications, 'notifications');
     await safeDelete(support, 'support');


### PR DESCRIPTION
Completes SO-03 backend APIs for organization role CRUD and member assignment, including optional org_unit_id / org_role_id support in existing member write endpoints while keeping legacy division / position behavior backward compatible. No UI changes, association request carry-over and Excel import assignment preservation are left for follow-up.