### PR TITLE
feat(lembaga): add acronym / nama singkatan to profile

### DIFF
--- a/drizzle/0024_tearful_korath.sql
+++ b/drizzle/0024_tearful_korath.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "anmategra_lembaga" ADD COLUMN "acronym" varchar(50);

--- a/drizzle/meta/0024_snapshot.json
+++ b/drizzle/meta/0024_snapshot.json
@@ -1,0 +1,2241 @@
+{
+  "id": "f779ba38-7a01-47c8-96df-1596ef405702",
+  "prevId": "2ee10c41-ce21-4143-ae2d-a5e63c858eaf",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.anmategra_account": {
+      "name": "anmategra_account",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anmategra_account_user_id_anmategra_user_id_fk": {
+          "name": "anmategra_account_user_id_anmategra_user_id_fk",
+          "tableFrom": "anmategra_account",
+          "tableTo": "anmategra_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "anmategra_account_provider_provider_account_id_pk": {
+          "name": "anmategra_account_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_association_request": {
+      "name": "anmategra_association_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_unit_id": {
+          "name": "org_unit_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_role_id": {
+          "name": "org_role_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "association_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_association_request_event_id_anmategra_event_id_fk": {
+          "name": "anmategra_association_request_event_id_anmategra_event_id_fk",
+          "tableFrom": "anmategra_association_request",
+          "tableTo": "anmategra_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "anmategra_association_request_user_id_anmategra_user_id_fk": {
+          "name": "anmategra_association_request_user_id_anmategra_user_id_fk",
+          "tableFrom": "anmategra_association_request",
+          "tableTo": "anmategra_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_association_request_lembaga": {
+      "name": "anmategra_association_request_lembaga",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lembaga_id": {
+          "name": "lembaga_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_unit_id": {
+          "name": "org_unit_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_role_id": {
+          "name": "org_role_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "association_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_association_request_lembaga_lembaga_id_anmategra_lembaga_id_fk": {
+          "name": "anmategra_association_request_lembaga_lembaga_id_anmategra_lembaga_id_fk",
+          "tableFrom": "anmategra_association_request_lembaga",
+          "tableTo": "anmategra_lembaga",
+          "columnsFrom": [
+            "lembaga_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "anmategra_association_request_lembaga_user_id_anmategra_user_id_fk": {
+          "name": "anmategra_association_request_lembaga_user_id_anmategra_user_id_fk",
+          "tableFrom": "anmategra_association_request_lembaga",
+          "tableTo": "anmategra_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_best_staff_kegiatan": {
+      "name": "anmategra_best_staff_kegiatan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mahasiswa_id": {
+          "name": "mahasiswa_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_best_staff_kegiatan_event_id_anmategra_event_id_fk": {
+          "name": "anmategra_best_staff_kegiatan_event_id_anmategra_event_id_fk",
+          "tableFrom": "anmategra_best_staff_kegiatan",
+          "tableTo": "anmategra_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "anmategra_best_staff_kegiatan_mahasiswa_id_anmategra_mahasiswa_user_id_fk": {
+          "name": "anmategra_best_staff_kegiatan_mahasiswa_id_anmategra_mahasiswa_user_id_fk",
+          "tableFrom": "anmategra_best_staff_kegiatan",
+          "tableTo": "anmategra_mahasiswa",
+          "columnsFrom": [
+            "mahasiswa_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_best_staff_lembaga": {
+      "name": "anmategra_best_staff_lembaga",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lembaga_id": {
+          "name": "lembaga_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mahasiswa_id": {
+          "name": "mahasiswa_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_best_staff_lembaga_lembaga_id_anmategra_lembaga_id_fk": {
+          "name": "anmategra_best_staff_lembaga_lembaga_id_anmategra_lembaga_id_fk",
+          "tableFrom": "anmategra_best_staff_lembaga",
+          "tableTo": "anmategra_lembaga",
+          "columnsFrom": [
+            "lembaga_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "anmategra_best_staff_lembaga_mahasiswa_id_anmategra_mahasiswa_user_id_fk": {
+          "name": "anmategra_best_staff_lembaga_mahasiswa_id_anmategra_mahasiswa_user_id_fk",
+          "tableFrom": "anmategra_best_staff_lembaga",
+          "tableTo": "anmategra_mahasiswa",
+          "columnsFrom": [
+            "mahasiswa_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_event": {
+      "name": "anmategra_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_image": {
+          "name": "background_image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oprec_link": {
+          "name": "oprec_link",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_limit": {
+          "name": "participant_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "participant_count": {
+          "name": "participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_highlighted": {
+          "name": "is_highlighted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_organogram": {
+          "name": "is_organogram",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "organogram_image": {
+          "name": "organogram_image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rapor_visible": {
+          "name": "rapor_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "event_org_highlighted_unique": {
+          "name": "event_org_highlighted_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"anmategra_event\".\"is_highlighted\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anmategra_event_org_id_anmategra_lembaga_id_fk": {
+          "name": "anmategra_event_org_id_anmategra_lembaga_id_fk",
+          "tableFrom": "anmategra_event",
+          "tableTo": "anmategra_lembaga",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_keanggotaan": {
+      "name": "anmategra_keanggotaan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_unit_id": {
+          "name": "org_unit_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_role_id": {
+          "name": "org_role_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "division": {
+          "name": "division",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "keanggotaan_event_user_unique": {
+          "name": "keanggotaan_event_user_unique",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anmategra_keanggotaan_event_id_anmategra_event_id_fk": {
+          "name": "anmategra_keanggotaan_event_id_anmategra_event_id_fk",
+          "tableFrom": "anmategra_keanggotaan",
+          "tableTo": "anmategra_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "anmategra_keanggotaan_user_id_anmategra_user_id_fk": {
+          "name": "anmategra_keanggotaan_user_id_anmategra_user_id_fk",
+          "tableFrom": "anmategra_keanggotaan",
+          "tableTo": "anmategra_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_kehimpunan": {
+      "name": "anmategra_kehimpunan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lembaga_id": {
+          "name": "lembaga_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_unit_id": {
+          "name": "org_unit_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_role_id": {
+          "name": "org_role_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "division": {
+          "name": "division",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "kehimpunan_lembaga_user_unique": {
+          "name": "kehimpunan_lembaga_user_unique",
+          "columns": [
+            {
+              "expression": "lembaga_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anmategra_kehimpunan_user_id_anmategra_user_id_fk": {
+          "name": "anmategra_kehimpunan_user_id_anmategra_user_id_fk",
+          "tableFrom": "anmategra_kehimpunan",
+          "tableTo": "anmategra_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "anmategra_kehimpunan_lembaga_id_anmategra_lembaga_id_fk": {
+          "name": "anmategra_kehimpunan_lembaga_id_anmategra_lembaga_id_fk",
+          "tableFrom": "anmategra_kehimpunan",
+          "tableTo": "anmategra_lembaga",
+          "columnsFrom": [
+            "lembaga_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_lembaga": {
+      "name": "anmategra_lembaga",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acronym": {
+          "name": "acronym",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "founding_date": {
+          "name": "founding_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ending_date": {
+          "name": "ending_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "lembaga_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "major": {
+          "name": "major",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field": {
+          "name": "field",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rapor_visible": {
+          "name": "rapor_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_lembaga_user_id_anmategra_user_id_fk": {
+          "name": "anmategra_lembaga_user_id_anmategra_user_id_fk",
+          "tableFrom": "anmategra_lembaga",
+          "tableTo": "anmategra_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_mahasiswa": {
+      "name": "anmategra_mahasiswa",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nim": {
+          "name": "nim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nim_tpb": {
+          "name": "nim_tpb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nama": {
+          "name": "nama",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jurusan": {
+          "name": "jurusan",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angkatan": {
+          "name": "angkatan",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "whatsapp": {
+          "name": "whatsapp",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rapor_visible": {
+          "name": "rapor_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_mahasiswa_user_id_anmategra_user_id_fk": {
+          "name": "anmategra_mahasiswa_user_id_anmategra_user_id_fk",
+          "tableFrom": "anmategra_mahasiswa",
+          "tableTo": "anmategra_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_nilai_profil_kegiatan": {
+      "name": "anmategra_nilai_profil_kegiatan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profil_id": {
+          "name": "profil_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mahasiswa_id": {
+          "name": "mahasiswa_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nilai": {
+          "name": "nilai",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "nilai_profil_kegiatan_unique": {
+          "name": "nilai_profil_kegiatan_unique",
+          "columns": [
+            {
+              "expression": "profil_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mahasiswa_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anmategra_nilai_profil_kegiatan_profil_id_anmategra_profil_kegiatan_id_fk": {
+          "name": "anmategra_nilai_profil_kegiatan_profil_id_anmategra_profil_kegiatan_id_fk",
+          "tableFrom": "anmategra_nilai_profil_kegiatan",
+          "tableTo": "anmategra_profil_kegiatan",
+          "columnsFrom": [
+            "profil_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "anmategra_nilai_profil_kegiatan_mahasiswa_id_anmategra_mahasiswa_user_id_fk": {
+          "name": "anmategra_nilai_profil_kegiatan_mahasiswa_id_anmategra_mahasiswa_user_id_fk",
+          "tableFrom": "anmategra_nilai_profil_kegiatan",
+          "tableTo": "anmategra_mahasiswa",
+          "columnsFrom": [
+            "mahasiswa_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_nilai_profil_lembaga": {
+      "name": "anmategra_nilai_profil_lembaga",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profil_id": {
+          "name": "profil_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mahasiswa_id": {
+          "name": "mahasiswa_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nilai": {
+          "name": "nilai",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "nilai_profil_lembaga_unique": {
+          "name": "nilai_profil_lembaga_unique",
+          "columns": [
+            {
+              "expression": "profil_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mahasiswa_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anmategra_nilai_profil_lembaga_profil_id_anmategra_profil_lembaga_id_fk": {
+          "name": "anmategra_nilai_profil_lembaga_profil_id_anmategra_profil_lembaga_id_fk",
+          "tableFrom": "anmategra_nilai_profil_lembaga",
+          "tableTo": "anmategra_profil_lembaga",
+          "columnsFrom": [
+            "profil_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "anmategra_nilai_profil_lembaga_mahasiswa_id_anmategra_mahasiswa_user_id_fk": {
+          "name": "anmategra_nilai_profil_lembaga_mahasiswa_id_anmategra_mahasiswa_user_id_fk",
+          "tableFrom": "anmategra_nilai_profil_lembaga",
+          "tableTo": "anmategra_mahasiswa",
+          "columnsFrom": [
+            "mahasiswa_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_notification": {
+      "name": "anmategra_notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_notification_user_id_anmategra_user_id_fk": {
+          "name": "anmategra_notification_user_id_anmategra_user_id_fk",
+          "tableFrom": "anmategra_notification",
+          "tableTo": "anmategra_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_organization_role": {
+      "name": "anmategra_organization_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "structure_id": {
+          "name": "structure_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ring_level": {
+          "name": "ring_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_organization_role_structure_id_anmategra_organization_structure_id_fk": {
+          "name": "anmategra_organization_role_structure_id_anmategra_organization_structure_id_fk",
+          "tableFrom": "anmategra_organization_role",
+          "tableTo": "anmategra_organization_structure",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_organization_structure": {
+      "name": "anmategra_organization_structure",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lembaga_id": {
+          "name": "lembaga_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_organization_structure_lembaga_id_anmategra_lembaga_id_fk": {
+          "name": "anmategra_organization_structure_lembaga_id_anmategra_lembaga_id_fk",
+          "tableFrom": "anmategra_organization_structure",
+          "tableTo": "anmategra_lembaga",
+          "columnsFrom": [
+            "lembaga_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "anmategra_organization_structure_event_id_anmategra_event_id_fk": {
+          "name": "anmategra_organization_structure_event_id_anmategra_event_id_fk",
+          "tableFrom": "anmategra_organization_structure",
+          "tableTo": "anmategra_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_organization_unit": {
+      "name": "anmategra_organization_unit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "structure_id": {
+          "name": "structure_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_organization_unit_structure_id_anmategra_organization_structure_id_fk": {
+          "name": "anmategra_organization_unit_structure_id_anmategra_organization_structure_id_fk",
+          "tableFrom": "anmategra_organization_unit",
+          "tableTo": "anmategra_organization_structure",
+          "columnsFrom": [
+            "structure_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "anmategra_organization_unit_parent_id_anmategra_organization_unit_id_fk": {
+          "name": "anmategra_organization_unit_parent_id_anmategra_organization_unit_id_fk",
+          "tableFrom": "anmategra_organization_unit",
+          "tableTo": "anmategra_organization_unit",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_pemetaan_profil_kegiatan": {
+      "name": "anmategra_pemetaan_profil_kegiatan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profil_kegiatan_id": {
+          "name": "profil_kegiatan_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profil_km_id": {
+          "name": "profil_km_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pemetaan_profil_kegiatan_profil_km_unique": {
+          "name": "pemetaan_profil_kegiatan_profil_km_unique",
+          "columns": [
+            {
+              "expression": "profil_kegiatan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profil_km_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anmategra_pemetaan_profil_kegiatan_profil_kegiatan_id_anmategra_profil_kegiatan_id_fk": {
+          "name": "anmategra_pemetaan_profil_kegiatan_profil_kegiatan_id_anmategra_profil_kegiatan_id_fk",
+          "tableFrom": "anmategra_pemetaan_profil_kegiatan",
+          "tableTo": "anmategra_profil_kegiatan",
+          "columnsFrom": [
+            "profil_kegiatan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "anmategra_pemetaan_profil_kegiatan_profil_km_id_anmategra_profil_km_id_fk": {
+          "name": "anmategra_pemetaan_profil_kegiatan_profil_km_id_anmategra_profil_km_id_fk",
+          "tableFrom": "anmategra_pemetaan_profil_kegiatan",
+          "tableTo": "anmategra_profil_km",
+          "columnsFrom": [
+            "profil_km_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_pemetaan_profil_lembaga": {
+      "name": "anmategra_pemetaan_profil_lembaga",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profil_lembaga_id": {
+          "name": "profil_lembaga_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profil_km_id": {
+          "name": "profil_km_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pemetaan_profil_lembaga_profil_km_unique": {
+          "name": "pemetaan_profil_lembaga_profil_km_unique",
+          "columns": [
+            {
+              "expression": "profil_lembaga_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profil_km_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anmategra_pemetaan_profil_lembaga_profil_lembaga_id_anmategra_profil_lembaga_id_fk": {
+          "name": "anmategra_pemetaan_profil_lembaga_profil_lembaga_id_anmategra_profil_lembaga_id_fk",
+          "tableFrom": "anmategra_pemetaan_profil_lembaga",
+          "tableTo": "anmategra_profil_lembaga",
+          "columnsFrom": [
+            "profil_lembaga_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "anmategra_pemetaan_profil_lembaga_profil_km_id_anmategra_profil_km_id_fk": {
+          "name": "anmategra_pemetaan_profil_lembaga_profil_km_id_anmategra_profil_km_id_fk",
+          "tableFrom": "anmategra_pemetaan_profil_lembaga",
+          "tableTo": "anmategra_profil_km",
+          "columnsFrom": [
+            "profil_km_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_profil_km": {
+      "name": "anmategra_profil_km",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_profil_kegiatan": {
+      "name": "anmategra_profil_kegiatan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_profil_kegiatan_event_id_anmategra_event_id_fk": {
+          "name": "anmategra_profil_kegiatan_event_id_anmategra_event_id_fk",
+          "tableFrom": "anmategra_profil_kegiatan",
+          "tableTo": "anmategra_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_profil_lembaga": {
+      "name": "anmategra_profil_lembaga",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lembaga_id": {
+          "name": "lembaga_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_profil_lembaga_lembaga_id_anmategra_lembaga_id_fk": {
+          "name": "anmategra_profil_lembaga_lembaga_id_anmategra_lembaga_id_fk",
+          "tableFrom": "anmategra_profil_lembaga",
+          "tableTo": "anmategra_lembaga",
+          "columnsFrom": [
+            "lembaga_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_session": {
+      "name": "anmategra_session",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "anmategra_session_user_id_anmategra_user_id_fk": {
+          "name": "anmategra_session_user_id_anmategra_user_id_fk",
+          "tableFrom": "anmategra_session",
+          "tableTo": "anmategra_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_support": {
+      "name": "anmategra_support",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "urgent": {
+          "name": "urgent",
+          "type": "support_urgent",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Low'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "support_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Draft'"
+        },
+        "attachment": {
+          "name": "attachment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_support_user_id_anmategra_user_id_fk": {
+          "name": "anmategra_support_user_id_anmategra_user_id_fk",
+          "tableFrom": "anmategra_support",
+          "tableTo": "anmategra_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_support_reply": {
+      "name": "anmategra_support_reply",
+      "schema": "",
+      "columns": {
+        "reply_id": {
+          "name": "reply_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "support_id": {
+          "name": "support_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anmategra_support_reply_user_id_anmategra_user_id_fk": {
+          "name": "anmategra_support_reply_user_id_anmategra_user_id_fk",
+          "tableFrom": "anmategra_support_reply",
+          "tableTo": "anmategra_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "anmategra_support_reply_support_id_anmategra_support_id_fk": {
+          "name": "anmategra_support_reply_support_id_anmategra_support_id_fk",
+          "tableFrom": "anmategra_support_reply",
+          "tableTo": "anmategra_support",
+          "columnsFrom": [
+            "support_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_user": {
+      "name": "anmategra_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mahasiswa'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "anmategra_user_email_unique": {
+          "name": "anmategra_user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    },
+    "public.anmategra_verification_token": {
+      "name": "anmategra_verification_token",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "anmategra_verification_token_identifier_token_pk": {
+          "name": "anmategra_verification_token_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.anmategra_verified_user": {
+      "name": "anmategra_verified_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.association_request_status": {
+      "name": "association_request_status",
+      "schema": "public",
+      "values": [
+        "Pending",
+        "Accepted",
+        "Declined"
+      ]
+    },
+    "public.event_status": {
+      "name": "event_status",
+      "schema": "public",
+      "values": [
+        "Coming Soon",
+        "On going",
+        "Ended"
+      ]
+    },
+    "public.lembaga_type": {
+      "name": "lembaga_type",
+      "schema": "public",
+      "values": [
+        "Himpunan",
+        "UKM",
+        "Kepanitiaan",
+        "BSO"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "Association Request",
+        "System"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "lembaga",
+        "mahasiswa"
+      ]
+    },
+    "public.support_status": {
+      "name": "support_status",
+      "schema": "public",
+      "values": [
+        "Open",
+        "In Progress",
+        "Resolved",
+        "Closed",
+        "Draft",
+        "Backlog",
+        "Reported"
+      ]
+    },
+    "public.support_urgent": {
+      "name": "support_urgent",
+      "schema": "public",
+      "values": [
+        "Low",
+        "Medium",
+        "High"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1786396556997,
       "tag": "0023_marvelous_robin_chapel",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1786959870493,
+      "tag": "0024_tearful_korath",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/lembaga/profile-lembaga/[lembagaId]/profile-lembaga-content.tsx
+++ b/src/app/lembaga/profile-lembaga/[lembagaId]/profile-lembaga-content.tsx
@@ -88,6 +88,11 @@ export default function ProfileLembagaContent({
                       <p className="text-xl md:text-3xl text-slate-600 font-semibold">
                         {lembagaData?.name}
                       </p>
+                      {lembagaData?.acronym && (
+                        <p className="text-base md:text-lg text-slate-400 font-medium">
+                          {lembagaData.acronym}
+                        </p>
+                      )}
                       <p className="text-sm md:text-xl text-slate-400">
                         {lembagaData?.description}
                       </p>

--- a/src/app/lembaga/profile-lembaga/_components/edit-profil-lembaga.tsx
+++ b/src/app/lembaga/profile-lembaga/_components/edit-profil-lembaga.tsx
@@ -36,12 +36,13 @@ const profileLembagaSchema = z.object({
   nama: z
     .string()
     .min(1, 'Nama wajib diisi')
-    .max(30, 'Nama maksimal 30 karakter'),
+    .max(255, 'Nama maksimal 255 karakter'),
+  singkatan: z.string().max(50, 'Singkatan maksimal 50 karakter').optional(),
   tipe: z.enum(lembagaTypeOptions).optional(),
   deskripsi: z
     .string()
     .min(10, 'Deskripsi minimal 10 karakter')
-    .max(100, 'Deskripsi maksimal 100 krakater'),
+    .max(500, 'Deskripsi maksimal 500 karakter'),
   gambar: z.string().url(),
 });
 type profileLembagaSchemaType = z.infer<typeof profileLembagaSchema>;
@@ -54,6 +55,7 @@ const EditProfileLembaga = ({
   lembagaData: {
     id: string;
     name: string;
+    acronym?: string | null;
     description: string | null;
     type?: (typeof lembagaTypeOptions)[number] | null;
     users: {
@@ -70,6 +72,7 @@ const EditProfileLembaga = ({
     resolver: zodResolver(profileLembagaSchema),
     defaultValues: {
       nama: lembagaData.name ?? '',
+      singkatan: lembagaData.acronym ?? '',
       tipe: lembagaData.type ?? undefined,
       deskripsi: lembagaData.description ?? '',
       gambar: lembagaData.users.image ?? '',
@@ -220,6 +223,27 @@ const EditProfileLembaga = ({
                         <FormControl>
                           <Input
                             placeholder="Masukkan nama lembaga"
+                            {...field}
+                            className="border rounded-xl border-neutral-400 bg-neutral-200 text-sm md:text-base"
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  {/* Nama Singkatan / Akronim */}
+                  <FormField
+                    control={form.control}
+                    name="singkatan"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className="font-normal text-neutral-1000 text-sm md:text-lg">
+                          Nama Singkatan
+                        </FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder="Contoh: HMTG"
                             {...field}
                             className="border rounded-xl border-neutral-400 bg-neutral-200 text-sm md:text-base"
                           />

--- a/src/server/api/routers/lembaga.ts
+++ b/src/server/api/routers/lembaga.ts
@@ -613,6 +613,9 @@ export const lembagaRouter = createTRPCRouter({
           name: input.nama,
           description: input.deskripsi,
           ...(input.tipe ? { type: input.tipe } : {}),
+          ...(input.singkatan !== undefined
+            ? { acronym: input.singkatan || null }
+            : {}),
         })
         .where(eq(lembaga.id, ctx.session.user.lembagaId!));
 

--- a/src/server/api/routers/profile.ts
+++ b/src/server/api/routers/profile.ts
@@ -119,6 +119,7 @@ export const profileRouter = createTRPCRouter({
         columns: {
           id: true,
           name: true,
+          acronym: true,
           description: true,
           memberCount: true,
           foundingDate: true,
@@ -306,6 +307,7 @@ export const profileRouter = createTRPCRouter({
         columns: {
           id: true,
           name: true,
+          acronym: true,
           description: true,
           memberCount: true,
           foundingDate: true,

--- a/src/server/api/types/lembaga.type.ts
+++ b/src/server/api/types/lembaga.type.ts
@@ -114,16 +114,22 @@ export const editAnggotaLembagaOutputSchema = z.object({
   success: z.boolean(),
 });
 
+// Limits track the real data: `lembaga.name` is varchar(255) (longest seeded
+// name is 73 chars), `lembaga.description` is text (longest seeded is 227).
+// The previous 30/100 caps rejected 62 of 135 names and 134 of 135
+// descriptions, so a seeded lembaga could not save its own profile at all.
 export const EditProfilLembagaInputSchema = z.object({
   nama: z
     .string()
+    .trim()
     .min(1, 'Nama wajib diisi')
-    .max(30, 'Nama maksimal 30 karakter'),
+    .max(255, 'Nama maksimal 255 karakter'),
   tipe: z.enum(['Himpunan', 'UKM', 'Kepanitiaan', 'BSO']).optional(),
   deskripsi: z
     .string()
+    .trim()
     .min(10, 'Deskripsi minimal 10 karakter')
-    .max(100, 'Deskripsi maksimal 100 karakter')
+    .max(500, 'Deskripsi maksimal 500 karakter')
     .optional(),
   gambar: z.string().url().optional(),
 });

--- a/src/server/api/types/lembaga.type.ts
+++ b/src/server/api/types/lembaga.type.ts
@@ -124,6 +124,11 @@ export const EditProfilLembagaInputSchema = z.object({
     .trim()
     .min(1, 'Nama wajib diisi')
     .max(255, 'Nama maksimal 255 karakter'),
+  singkatan: z
+    .string()
+    .trim()
+    .max(50, 'Singkatan maksimal 50 karakter')
+    .optional(),
   tipe: z.enum(['Himpunan', 'UKM', 'Kepanitiaan', 'BSO']).optional(),
   deskripsi: z
     .string()

--- a/src/server/api/types/profile.type.ts
+++ b/src/server/api/types/profile.type.ts
@@ -43,6 +43,7 @@ export const GetLembagaOutputSchema = z.object({
   lembagaData: z.object({
     id: z.string(),
     name: z.string(),
+    acronym: z.string().nullable(),
     description: z.string().nullable(),
     memberCount: z.number().nullable(),
     foundingDate: z.date().nullable(),

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -179,6 +179,7 @@ export const lembaga = createTable('lembaga', {
     .references(() => users.id, { onDelete: 'cascade' })
     .notNull(),
   name: varchar('name', { length: 255 }).notNull(),
+  acronym: varchar('acronym', { length: 50 }),
   description: text('description'),
   foundingDate: timestamp('founding_date', {
     mode: 'date',

--- a/src/server/db/seeding/data/README.md
+++ b/src/server/db/seeding/data/README.md
@@ -36,7 +36,17 @@ Emails come from a human source — an updated sheet from the lead, or the org's
 
 **Add one new lembaga by hand.** Append a row to `lembaga-official.csv` (minimum: `email`, `name`, `type`) and re-run `npm run db:seed-lembaga`. When new orgs arrive as part of a whole new spreadsheet, use the refresh pipeline below instead.
 
-**Change or remove an existing account.** The seed cannot do this (see the add-only limitation below) — edit the database directly.
+**Change an existing account.** Edit the row in `lembaga-official.csv` and re-run the seed — it updates any lembaga whose stored values disagree with the CSV. Always dry-run first: the CSV wins, so an update silently replaces whatever is in the database, including edits a lembaga made through the app.
+
+```
+npm run db:seed-lembaga -- --dry-run       # prints every field as "old -> new"
+npm run db:seed-lembaga
+npm run db:seed-lembaga -- --insert-only   # add new orgs, touch nothing existing
+```
+
+A blank CSV cell means "unknown", never "clear this" — an empty cell leaves a populated column alone, so blanking a field still has to be done in the database. Only `name`, `description`, `founding_date`, `ending_date`, `type`, `major`, `field` and `member_count` are ever written; a name change also updates `users.name`, which is what the logged-in sidebar shows. Dates compare on their **Jakarta calendar date**, so a value stored at WIB midnight is not mistaken for a different day.
+
+**Remove an account.** The seed never deletes — do it in the database directly.
 
 ## How this CSV was built (one-shot pipeline)
 
@@ -44,7 +54,7 @@ Emails come from a human source — an updated sheet from the lead, or the org's
 2. `scripts/build-lembaga-csv.py` → baseline CSV — descriptions + inferred majors/fields (**no emails**)
 3. `scripts/merge-lembaga-xlsx.cjs <xlsx>` → `raw/merge-report.csv` — matches the baseline against the official KM ITB database
 4. `scripts/apply-merge.cjs <xlsx>` → patches the baseline (emails, founding dates, member counts, official prodi/rumpun) and appends the team-approved additions (16 new UKMs, 6 Cirebon komisariat, 2 BSO)
-5. `npm run db:seed-lembaga [-- --dry-run]` — idempotent loader; `LEMBAGA_CSV=<path>` env var points it at another file (e.g. a synthetic-email copy for testing)
+5. `npm run db:seed-lembaga [-- --dry-run]` — idempotent loader; inserts new accounts and updates changed ones. `LEMBAGA_CSV=<path>` env var points it at another file (e.g. a synthetic-email copy for testing)
 
 **Next period's spreadsheet?** One command re-runs steps 2–4 deterministically:
 
@@ -56,9 +66,11 @@ Changed emails/dates/counts propagate on re-run. Orgs the sheet lists that we do
 have yet show up as `unmatched theirs` in the merge summary — add a one-line entry to
 `ADDITIONS` in `scripts/apply-merge.cjs` (with a hand-written description) and re-run.
 
-**Limitation — the seed is add-only:** it never updates or deletes existing accounts.
-If an org's email changes, seeding adds a second account and orphans the old one; a
-disbanded org stays until removed from the DB by hand.
+**Limitation — email is the join key:** rows are matched to existing accounts by
+email, so a *changed* email is not an update, it is a new account — seeding adds a
+second one and orphans the old (along with anything the org filled in through the
+app). Fix the email in the database first, then seed. Deletions are never
+automatic: a disbanded org stays until removed by hand.
 
 ## Cautions
 

--- a/src/server/db/seeding/data/README.md
+++ b/src/server/db/seeding/data/README.md
@@ -16,6 +16,7 @@
 |---|---|---|
 | `email` | yes | rows without email are skipped by the seed with a named warning |
 | `name` | yes | |
+| `acronym` | no | short name / nama singkatan, e.g. `HMTG` (max 50 chars); blank leaves any existing value alone |
 | `description` | no | neutral factual Indonesian, 1–2 sentences |
 | `founding_date` | no | ISO date; unknown stays null (column nullable since migration `0017`) |
 | `type` | yes | `Himpunan` / `UKM` / `Kepanitiaan` / `BSO` (`BSO` added in migration `0018`) |
@@ -44,9 +45,37 @@ npm run db:seed-lembaga
 npm run db:seed-lembaga -- --insert-only   # add new orgs, touch nothing existing
 ```
 
-A blank CSV cell means "unknown", never "clear this" — an empty cell leaves a populated column alone, so blanking a field still has to be done in the database. Only `name`, `description`, `founding_date`, `ending_date`, `type`, `major`, `field` and `member_count` are ever written; a name change also updates `users.name`, which is what the logged-in sidebar shows. Dates compare on their **Jakarta calendar date**, so a value stored at WIB midnight is not mistaken for a different day.
+A blank CSV cell means "unknown", never "clear this" — an empty cell leaves a populated column alone, so blanking a field still has to be done in the database. Only `name`, `acronym`, `description`, `founding_date`, `ending_date`, `type`, `major`, `field` and `member_count` are ever written; a name change also updates `users.name`, which is what the logged-in sidebar shows. Dates compare on their **Jakarta calendar date**, so a value stored at WIB midnight is not mistaken for a different day.
 
 **Remove an account.** The seed never deletes — do it in the database directly.
+
+## Import from a Google Form (acronym / description)
+
+Profile fields collected from lembaga through a Google Form (e.g. `acronym` /
+nama singkatan, `description`) load through this same seed — **no xlsx step**. The
+form's response sheet becomes a CSV the seed reads directly via `LEMBAGA_CSV`, so
+you never have to touch the committed `lembaga-official.csv`.
+
+1. In the responses Google Sheet: **File → Download → Comma-separated values (.csv)**.
+2. Rename the columns so the headers match the seed's names: **`email`** (required —
+   the join key) plus any of **`acronym`**, **`description`**. Columns the form does
+   not collect can be left out entirely; a blank cell means "leave the stored value
+   alone", never "clear it".
+3. Load it, pointing `LEMBAGA_CSV` at your file (dry-run first — the CSV wins and
+   overwrites app edits for any field it fills):
+
+```
+LEMBAGA_CSV=/path/to/form-responses.csv npm run db:seed-lembaga -- --dry-run   # review every old -> new
+LEMBAGA_CSV=/path/to/form-responses.csv npm run db:seed-lembaga                # write for real
+```
+
+**`email` is the join key** — it must exactly match the email on the lembaga's
+account, or the seed treats the row as a brand-new org (a duplicate account), not
+an update. Pre-fill or validate the email question in the form.
+
+**Logo is not imported this way.** A Google Form file upload lands in Drive as a URL
+that will not render, and the logo lives on `users.image`, not a `lembaga` column.
+Have each lembaga upload their logo through the in-app profile form instead.
 
 ## How this CSV was built (one-shot pipeline)
 

--- a/src/server/db/seeding/seed-lembaga.ts
+++ b/src/server/db/seeding/seed-lembaga.ts
@@ -7,18 +7,30 @@
  *                                           instead of the auto-created placeholder)
  *   3. lembaga         <- profile row      (name, type, founding_date, ...)
  *
- * Idempotent: existing emails/users/lembaga are detected up front and skipped,
- * so re-running never duplicates. Verified against two consecutive runs.
+ * Idempotent: existing emails/users are detected up front and skipped, so
+ * re-running never duplicates. Verified against two consecutive runs.
+ *
+ * Existing lembaga rows are UPDATED when the CSV disagrees with the database.
+ * A blank CSV cell means "unknown", never "clear this" — blanks are normal in
+ * this data (no ending_date, no major for UKM), so an empty cell leaves a
+ * populated column alone. Only genuinely differing fields are written, and
+ * --dry-run prints the exact before/after for each one.
+ *
+ * Careful: the CSV wins on every run. Once lembaga edit their own profile
+ * through the app, re-seeding overwrites those edits for any field the CSV
+ * also fills. Use --dry-run first, or --insert-only to add new orgs without
+ * touching existing ones.
  *
  * Usage:
- *   npm run db:seed-lembaga            # write to DATABASE_URL
- *   npm run db:seed-lembaga -- --dry-run  # print the plan, write nothing
+ *   npm run db:seed-lembaga                   # insert new + update changed
+ *   npm run db:seed-lembaga -- --dry-run      # print the plan, write nothing
+ *   npm run db:seed-lembaga -- --insert-only  # insert new, never update
  *
  * CSV format: see data/README.md.
  */
 import { parse } from 'csv-parse/sync';
 import 'dotenv/config';
-import { inArray } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 import fs from 'fs';
 import path from 'path';
 
@@ -26,6 +38,7 @@ import { db } from '../index.js';
 import { lembaga, users, verifiedUsers } from '../schema.js';
 
 const DRY_RUN = process.argv.includes('--dry-run');
+const INSERT_ONLY = process.argv.includes('--insert-only');
 
 const CSV_PATH =
   process.env.LEMBAGA_CSV ??
@@ -86,9 +99,7 @@ function readCsv(): Row[] {
     }
     const rawType = rec.type ?? '';
     if (rawType && !LEMBAGA_TYPES.includes(rawType as LembagaType)) {
-      console.warn(
-        `line ${line}: invalid type "${rawType}" — leaving null`,
-      );
+      console.warn(`line ${line}: invalid type "${rawType}" — leaving null`);
     }
     const memberCount = rec.member_count
       ? parseInt(rec.member_count, 10)
@@ -113,6 +124,100 @@ function readCsv(): Row[] {
   return rows;
 }
 
+/** The lembaga columns this CSV owns — the only ones an update ever touches. */
+const UPDATABLE = [
+  'name',
+  'description',
+  'foundingDate',
+  'endingDate',
+  'type',
+  'major',
+  'field',
+  'memberCount',
+] as const;
+type UpdatableField = (typeof UPDATABLE)[number];
+
+type ExistingLembaga = Pick<Row, UpdatableField> & {
+  id: string;
+  userId: string;
+};
+
+interface Change {
+  field: UpdatableField;
+  from: unknown;
+  to: unknown;
+}
+
+interface PlannedUpdate {
+  row: Row;
+  lembagaId: string;
+  userId: string;
+  changes: Change[];
+}
+
+/**
+ * founding_date / ending_date are calendar dates living in a timestamptz, and
+ * the two write paths disagree on the time-of-day: this seed parses "2006-03-08"
+ * to UTC midnight, while other paths store WIB midnight (2006-03-07T17:00Z).
+ * Both mean 8 March in Bandung, so compare the Jakarta calendar date — instant
+ * equality would report a difference that no human would call one.
+ */
+function jakartaDate(d: Date): string {
+  return d.toLocaleDateString('en-CA', { timeZone: 'Asia/Jakarta' });
+}
+
+function sameValue(a: unknown, b: unknown): boolean {
+  if (a instanceof Date && b instanceof Date)
+    return jakartaDate(a) === jakartaDate(b);
+  return a === b;
+}
+
+function fmt(v: unknown): string {
+  if (v === null || v === undefined) return '(kosong)';
+  if (v instanceof Date) return jakartaDate(v);
+  const s = String(v);
+  return s.length > 60 ? `${s.slice(0, 57)}...` : s;
+}
+
+/** Fields where the CSV has a value that differs from what is already stored. */
+function diffLembaga(row: Row, existing: ExistingLembaga): Change[] {
+  const changes: Change[] = [];
+  for (const field of UPDATABLE) {
+    const next = row[field];
+    if (next === null) continue; // blank CSV cell = unknown, never a clear
+    const current = existing[field];
+    if (!sameValue(current, next))
+      changes.push({ field, from: current, to: next });
+  }
+  return changes;
+}
+
+async function applyUpdate(update: PlannedUpdate): Promise<void> {
+  const { row } = update;
+  const changed = new Set<UpdatableField>(update.changes.map((c) => c.field));
+  const set: Partial<typeof lembaga.$inferInsert> = {};
+
+  if (changed.has('name')) set.name = row.name;
+  if (changed.has('description')) set.description = row.description;
+  if (changed.has('foundingDate')) set.foundingDate = row.foundingDate;
+  if (changed.has('endingDate')) set.endingDate = row.endingDate;
+  if (changed.has('type')) set.type = row.type;
+  if (changed.has('major')) set.major = row.major;
+  if (changed.has('field')) set.field = row.field;
+  if (changed.has('memberCount')) set.memberCount = row.memberCount;
+
+  await db.update(lembaga).set(set).where(eq(lembaga.id, update.lembagaId));
+
+  // users.name is what the logged-in sidebar renders, and the insert path sets
+  // it from the same CSV column — keep the two from drifting on rename.
+  if (changed.has('name')) {
+    await db
+      .update(users)
+      .set({ name: row.name })
+      .where(eq(users.id, update.userId));
+  }
+}
+
 async function main() {
   console.log('Seeding official lembaga accounts');
   console.log(`CSV: ${CSV_PATH}`);
@@ -132,7 +237,9 @@ async function main() {
     return true;
   });
   if (unique.length < rows.length) {
-    console.warn(`${rows.length - unique.length} duplicate email(s) in CSV ignored`);
+    console.warn(
+      `${rows.length - unique.length} duplicate email(s) in CSV ignored`,
+    );
   }
 
   const emails = unique.map((r) => r.email);
@@ -153,16 +260,35 @@ async function main() {
         .where(inArray(users.email, emails))
     ).map((r) => [r.email, r.id] as const),
   );
-  const existingLembagaByUser = new Set(
+  const existingLembagaRows: ExistingLembaga[] =
     existingUsers.size > 0
-      ? (
-          await db
-            .select({ userId: lembaga.userId })
-            .from(lembaga)
-            .where(inArray(lembaga.userId, [...existingUsers.values()]))
-        ).map((r) => r.userId)
-      : [],
-  );
+      ? await db
+          .select({
+            id: lembaga.id,
+            userId: lembaga.userId,
+            name: lembaga.name,
+            description: lembaga.description,
+            foundingDate: lembaga.foundingDate,
+            endingDate: lembaga.endingDate,
+            type: lembaga.type,
+            major: lembaga.major,
+            field: lembaga.field,
+            memberCount: lembaga.memberCount,
+          })
+          .from(lembaga)
+          .where(inArray(lembaga.userId, [...existingUsers.values()]))
+      : [];
+
+  const existingLembagaByUser = new Map<string, ExistingLembaga>();
+  for (const r of existingLembagaRows) {
+    if (existingLembagaByUser.has(r.userId)) {
+      console.warn(
+        `user ${r.userId} has more than one lembaga row — updating the first, leaving ${r.id} alone`,
+      );
+      continue;
+    }
+    existingLembagaByUser.set(r.userId, r);
+  }
 
   const newVerified = unique.filter((r) => !existingVerified.has(r.email));
   const newUsers = unique.filter((r) => !existingUsers.has(r.email));
@@ -172,6 +298,20 @@ async function main() {
     return userId === undefined || !existingLembagaByUser.has(userId);
   });
 
+  const updates: PlannedUpdate[] = [];
+  if (!INSERT_ONLY) {
+    for (const r of unique) {
+      const userId = existingUsers.get(r.email);
+      if (userId === undefined) continue;
+      const existing = existingLembagaByUser.get(userId);
+      if (!existing) continue;
+      const changes = diffLembaga(r, existing);
+      if (changes.length > 0) {
+        updates.push({ row: r, lembagaId: existing.id, userId, changes });
+      }
+    }
+  }
+
   console.log(`rows: ${unique.length}`);
   console.log(
     `   verified_users: ${newVerified.length} new (${unique.length - newVerified.length} exist)`,
@@ -179,15 +319,35 @@ async function main() {
   console.log(
     `   users:          ${newUsers.length} new (${unique.length - newUsers.length} exist)`,
   );
+  const unchanged = unique.length - newLembaga.length - updates.length;
   console.log(
-    `   lembaga:        ${newLembaga.length} new (${unique.length - newLembaga.length} exist)\n`,
+    `   lembaga:        ${newLembaga.length} new, ${updates.length} to update, ${unchanged} unchanged` +
+      `${INSERT_ONLY ? '  (--insert-only: updates disabled)' : ''}\n`,
   );
+
+  const updateByRow = new Map(updates.map((u) => [u.row, u] as const));
 
   if (DRY_RUN) {
     for (const r of unique) {
+      const update = updateByRow.get(r);
+      const lembagaPlan = newLembaga.includes(r)
+        ? 'insert'
+        : update
+          ? `update(${update.changes.length})`
+          : 'skip';
       console.log(
-        `   ${r.email} -> verified:${existingVerified.has(r.email) ? 'skip' : 'insert'} user:${existingUsers.has(r.email) ? 'skip' : 'insert'} lembaga:${newLembaga.includes(r) ? 'insert' : 'skip'} — "${r.name}"`,
+        `   ${r.email} -> verified:${existingVerified.has(r.email) ? 'skip' : 'insert'} user:${existingUsers.has(r.email) ? 'skip' : 'insert'} lembaga:${lembagaPlan} — "${r.name}"`,
       );
+    }
+
+    if (updates.length > 0) {
+      console.log(`\nchanges (${updates.length} lembaga):`);
+      for (const u of updates) {
+        console.log(`   ${u.row.name} (${u.row.email})`);
+        for (const c of u.changes) {
+          console.log(`      ${c.field}: ${fmt(c.from)} -> ${fmt(c.to)}`);
+        }
+      }
     }
     return;
   }
@@ -235,6 +395,16 @@ async function main() {
       })),
     );
     console.log(`lembaga: +${newLembaga.length}`);
+  }
+
+  if (updates.length > 0) {
+    for (const u of updates) {
+      await applyUpdate(u);
+      console.log(
+        `lembaga updated: ${u.row.name} — ${u.changes.map((c) => c.field).join(', ')}`,
+      );
+    }
+    console.log(`lembaga: ~${updates.length} updated`);
   }
 
   console.log('\nDone.');

--- a/src/server/db/seeding/seed-lembaga.ts
+++ b/src/server/db/seeding/seed-lembaga.ts
@@ -58,6 +58,7 @@ type LembagaType = (typeof LEMBAGA_TYPES)[number];
 interface Row {
   email: string;
   name: string;
+  acronym: string | null;
   description: string | null;
   foundingDate: Date | null;
   endingDate: Date | null;
@@ -108,6 +109,7 @@ function readCsv(): Row[] {
     rows.push({
       email,
       name,
+      acronym: rec.acronym || null,
       description: rec.description || null,
       foundingDate,
       endingDate: parseDate(rec.ending_date),
@@ -127,6 +129,7 @@ function readCsv(): Row[] {
 /** The lembaga columns this CSV owns — the only ones an update ever touches. */
 const UPDATABLE = [
   'name',
+  'acronym',
   'description',
   'foundingDate',
   'endingDate',
@@ -198,6 +201,7 @@ async function applyUpdate(update: PlannedUpdate): Promise<void> {
   const set: Partial<typeof lembaga.$inferInsert> = {};
 
   if (changed.has('name')) set.name = row.name;
+  if (changed.has('acronym')) set.acronym = row.acronym;
   if (changed.has('description')) set.description = row.description;
   if (changed.has('foundingDate')) set.foundingDate = row.foundingDate;
   if (changed.has('endingDate')) set.endingDate = row.endingDate;
@@ -267,6 +271,7 @@ async function main() {
             id: lembaga.id,
             userId: lembaga.userId,
             name: lembaga.name,
+            acronym: lembaga.acronym,
             description: lembaga.description,
             foundingDate: lembaga.foundingDate,
             endingDate: lembaga.endingDate,
@@ -385,6 +390,7 @@ async function main() {
         id: crypto.randomUUID(),
         userId: userIdByEmail.get(r.email)!,
         name: r.name,
+        acronym: r.acronym,
         description: r.description,
         foundingDate: r.foundingDate,
         endingDate: r.endingDate,


### PR DESCRIPTION
## Summary

Adds **acronym / nama singkatan** as a first-class lembaga profile attribute, wired through the whole stack, and documents a Google Form → CSV import path for bulk-collecting profile data. Also includes earlier BE groundwork on the lembaga seed (field limits + idempotent re-seed updates).

Logo and description needed no new schema — description is already a column, and the logo already works via the in-app form (`users.image`).

## What changed

**Schema / migration**
- New nullable `acronym varchar(50)` column on `lembaga`.
- Migration `drizzle/0024_tearful_korath.sql` — `ADD COLUMN`, non-destructive.

**Import (seed)**
- `seed-lembaga.ts` reads/writes `acronym` on both the insert and idempotent-update paths (blank cell = "leave existing alone", consistent with every other column).
- New **"Import from a Google Form"** section in the seeding README: export responses as CSV, match headers (`email` join key + `acronym`/`description`), load via `LEMBAGA_CSV=<path> npm run db:seed-lembaga`. No xlsx step.

**API**
- `editProfil` mutation accepts `singkatan` and writes `acronym` (absent → unchanged, empty → null).
- `getLembaga` + `getLembagaPublic` select and return `acronym`.

**UI**
- New "Nama Singkatan" field in the in-app profile edit form; acronym shown on the profile page.
- Aligned the form's stale zod caps (`nama` 30→255, `deskripsi` 100→500) with the server schema, which was silently rejecting real data.

The codebase's existing bilingual split is preserved: DB/read use `acronym` (like `name`/`description`), the edit input/form uses `singkatan` (like `nama`/`deskripsi`).

## Deploy note

⚠️ The migration must be applied after merge: `npm run db:migrate`. The code + migration file are shipped, but the column is not added to the database until migrate runs.

## Notes / non-goals

- **Logo is intentionally not imported via the seed** — Google Form uploads are Drive URLs that don't render, and the logo lives on `users.image`, not a `lembaga` column. Logos are uploaded per-lembaga through the in-app form.
- **`email` is the seed's join key** — a mismatched email creates a duplicate account instead of updating; the form must capture the account's exact email.

## Testing

- `tsc --noEmit` clean across all changed files (one pre-existing, unrelated `@next/third-parties/google` error in `layout.tsx` remains).
- `db:generate` produced the migration cleanly; the seed was **not** run against a live database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
